### PR TITLE
fix(features): stop leaking default features through cli and lsp dep edges

### DIFF
--- a/crates/vibelang-cli/Cargo.toml
+++ b/crates/vibelang-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 
 [features]
 default = ["midi", "api", "lsp", "extensions"]
-midi = ["vibelang-core/midi", "vibelang-rhai/midi", "dep:midir"]
+midi = ["vibelang-core/midi", "vibelang-rhai/midi", "vibelang-http?/midi", "dep:midir"]
 api = ["dep:vibelang-http"]
 lsp = ["dep:vibelang-lsp"]
 
@@ -26,8 +26,8 @@ ext-net = ["vibelang-rhai/ext-net"]
 
 [dependencies]
 # Core runtime
-vibelang-core = { version = "0.4.0", features = ["native"] }
-vibelang-rhai = "0.4.0"
+vibelang-core = { version = "0.4.0", default-features = false, features = ["native"] }
+vibelang-rhai = { version = "0.4.0", default-features = false, features = ["native"] }
 vibelang-dsp = "0.4.0"
 vibelang-std = "0.4.0"
 
@@ -35,7 +35,7 @@ vibelang-std = "0.4.0"
 vibelang-lsp = { version = "0.4.0", optional = true }
 
 # HTTP REST API server
-vibelang-http = { version = "0.4.0", optional = true }
+vibelang-http = { version = "0.4.0", optional = true, default-features = false, features = ["native"] }
 
 # Rhai engine — needed for the MIDI dispatcher to call Rhai FnPtrs
 rhai = { version = "1", features = ["sync"] }

--- a/crates/vibelang-lsp/Cargo.toml
+++ b/crates/vibelang-lsp/Cargo.toml
@@ -10,10 +10,10 @@ categories = ["development-tools"]
 
 [dependencies]
 # Core runtime (for validation)
-vibelang-core = "0.4.0"
+vibelang-core = { version = "0.4.0", default-features = false, features = ["native"] }
 
 # Rhai scripting layer
-vibelang-rhai = "0.4.0"
+vibelang-rhai = { version = "0.4.0", default-features = false, features = ["native"] }
 
 # Rhai engine (for error types)
 rhai = { version = "1", features = ["sync"] }


### PR DESCRIPTION
## Problem

`vibelang-cli` and `vibelang-lsp` declare their `vibelang-core`/`vibelang-rhai`/`vibelang-http` dependencies without `default-features = false`. Since core's default features include `midi` → `pipewire-midi2` → `pipewire`/`libspa-sys` (and `midir` → `alsa-sys`), the native PipeWire/ALSA stack is unconditionally in the dependency graph: `--no-default-features` on the CLI can never produce a build without a PipeWire pkg-config sysroot. This blocks cross-compilation to targets without those libs (concretely: aarch64 embedded boards — Bela Gem/PocketBeagle 2, where the board build has no PipeWire and MIDI is handled by a separate daemon).

## Fix

Four dependency edges gain `default-features = false` (+ explicit `features = ["native"]`), and the cli `midi` feature forwards `vibelang-http?/midi` so default builds keep HTTP-side MIDI.

## Verification

- Default desktop build resolves identically: `cargo tree -i pipewire -p vibelang-cli` still shows pipewire, core features still `[midi,native,pipewire-midi2,rosc]`.
- Gated board profile now resolves cleanly: `cargo tree --target aarch64-unknown-linux-gnu -i libspa-sys -p vibelang-cli --no-default-features --features api,lsp,extensions` → no match.
- Cross-built with `cross` for `aarch64-unknown-linux-gnu` and verified executing on a Bela Gem (Debian 12, glibc 2.36): `vibe 0.4.0`.

Suggested follow-up: add the gated feature combination to CI so it stays compiling (it had never compiled before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)