### PR TITLE
feat(features): split pipewire-midi2 from midi so MIDI builds on embedded targets

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,36 @@
+# cross-rs configuration for embedded/cross builds.
+#
+# The `midi` feature pulls midir -> alsa-sys, whose build script needs
+# ALSA headers for the *target* architecture. The stock cross images ship
+# host-arch dev packages only, so install the target-arch ALSA headers and
+# point pkg-config at them.
+#
+# Build the embedded profile (no PipeWire — see vibelang-core's
+# `pipewire-midi2` feature) with:
+#
+#   cross build --release --target aarch64-unknown-linux-gnu -p vibelang-cli \
+#     --no-default-features --features midi,api,lsp,extensions
+
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "dpkg --add-architecture arm64",
+    "apt-get update && apt-get install -y libasound2-dev:arm64",
+]
+
+[target.aarch64-unknown-linux-gnu.env]
+passthrough = [
+    "PKG_CONFIG_ALLOW_CROSS=1",
+    "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig",
+]
+
+[target.armv7-unknown-linux-gnueabihf]
+pre-build = [
+    "dpkg --add-architecture armhf",
+    "apt-get update && apt-get install -y libasound2-dev:armhf",
+]
+
+[target.armv7-unknown-linux-gnueabihf.env]
+passthrough = [
+    "PKG_CONFIG_ALLOW_CROSS=1",
+    "PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig",
+]

--- a/crates/vibelang-cli/Cargo.toml
+++ b/crates/vibelang-cli/Cargo.toml
@@ -13,8 +13,11 @@ name = "vibe"
 path = "src/main.rs"
 
 [features]
-default = ["midi", "api", "lsp", "extensions"]
+default = ["midi", "pipewire-midi2", "api", "lsp", "extensions"]
+# MIDI I/O via midir (ALSA/CoreMIDI/WinMM). Buildable on embedded targets.
 midi = ["vibelang-core/midi", "vibelang-rhai/midi", "vibelang-http?/midi", "dep:midir"]
+# PipeWire-native MIDI 2.0 inputs — desktop Linux only (native libspa/pipewire).
+pipewire-midi2 = ["midi", "vibelang-core/pipewire-midi2"]
 api = ["dep:vibelang-http"]
 lsp = ["dep:vibelang-lsp"]
 

--- a/crates/vibelang-core/Cargo.toml
+++ b/crates/vibelang-core/Cargo.toml
@@ -9,8 +9,12 @@ repository = "https://github.com/trusch/vibelang"
 [features]
 default = ["native", "midi"]
 native = ["rosc"]
-midi = ["dep:midir", "pipewire-midi2"]
-pipewire-midi2 = ["dep:libspa", "dep:pipewire"]
+# MIDI I/O via midir (ALSA on Linux, CoreMIDI on macOS, WinMM on Windows).
+midi = ["dep:midir"]
+# PipeWire-native MIDI 2.0 inputs. Additive on top of `midi`; separate because
+# libspa/pipewire are native deps that are unavailable on embedded targets
+# (and impossible to cross-compile without a target pkg-config sysroot).
+pipewire-midi2 = ["midi", "dep:libspa", "dep:pipewire"]
 
 [dependencies]
 async-trait = "0.1"

--- a/crates/vibelang-core/src/handlers/midi/mod.rs
+++ b/crates/vibelang-core/src/handlers/midi/mod.rs
@@ -58,8 +58,10 @@ use crate::compat::RwLock;
 use crate::midi::{
     CallbackData, CallbackType, CcRouteBuilder, KeyboardRouteBuilder, MidiClock, MidiEventQueue,
     MidiEventSender, MidiMessage as NewMidiMessage, MidiRealtimeService, MidiRecording,
-    NoteRouteBuilder, PipeWireMidiInputConnection, ScheduledMidiEvent, TimestampedMidiEvent,
+    NoteRouteBuilder, ScheduledMidiEvent, TimestampedMidiEvent,
 };
+#[cfg(feature = "pipewire-midi2")]
+use crate::midi::PipeWireMidiInputConnection;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::transport_snapshot::TransportSnapshot;
 
@@ -187,6 +189,7 @@ pub struct MidiHandler<B: Backend> {
     outputs: Arc<Mutex<HashMap<MidiDeviceId, MidiOutputConnection>>>,
 
     /// Open PipeWire raw UMP input connections.
+    #[cfg(feature = "pipewire-midi2")]
     pipewire_inputs: Arc<Mutex<HashMap<MidiDeviceId, PipeWireMidiInputConnection>>>,
 
     /// Incoming MIDI message channel (legacy).
@@ -301,6 +304,7 @@ impl<B: Backend> MidiHandler<B> {
             state,
             inputs: Arc::new(Mutex::new(HashMap::new())),
             outputs: Arc::new(Mutex::new(HashMap::new())),
+            #[cfg(feature = "pipewire-midi2")]
             pipewire_inputs: Arc::new(Mutex::new(HashMap::new())),
             rx: Arc::new(Mutex::new(rx)),
             tx,

--- a/crates/vibelang-core/src/handlers/midi/mod.rs
+++ b/crates/vibelang-core/src/handlers/midi/mod.rs
@@ -55,13 +55,13 @@ pub use types::{map_to_range, Midi2ControllerType};
 
 use crate::backend::Backend;
 use crate::compat::RwLock;
+#[cfg(feature = "pipewire-midi2")]
+use crate::midi::PipeWireMidiInputConnection;
 use crate::midi::{
     CallbackData, CallbackType, CcRouteBuilder, KeyboardRouteBuilder, MidiClock, MidiEventQueue,
     MidiEventSender, MidiMessage as NewMidiMessage, MidiRealtimeService, MidiRecording,
     NoteRouteBuilder, ScheduledMidiEvent, TimestampedMidiEvent,
 };
-#[cfg(feature = "pipewire-midi2")]
-use crate::midi::PipeWireMidiInputConnection;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::transport_snapshot::TransportSnapshot;
 

--- a/crates/vibelang-core/src/handlers/midi/trait_impl.rs
+++ b/crates/vibelang-core/src/handlers/midi/trait_impl.rs
@@ -5,10 +5,12 @@ use super::types::convert_new_to_legacy_message;
 use super::MidiHandler;
 use crate::backend::Backend;
 use crate::midi::{
-    is_pipewire_midi_input_id, list_pipewire_midi2_inputs, open_pipewire_midi2_input,
+    is_pipewire_midi_input_id, list_pipewire_midi2_inputs,
     parse_midi_bytes as new_parse_midi_bytes, MidiRecording, MidiRecordingInfo, QueuedMidiEvent,
     TimestampedMidiEvent,
 };
+#[cfg(feature = "pipewire-midi2")]
+use crate::midi::open_pipewire_midi2_input;
 use crate::traits::{Midi, MidiDeviceInfo, MidiOutputCapability};
 use crate::types::ids::MidiDeviceId;
 use crate::types::VoiceId;
@@ -78,6 +80,7 @@ impl<B: Backend> Midi for MidiHandler<B> {
     }
 
     async fn open_input(&self, id: MidiDeviceId) -> Result<()> {
+        #[cfg(feature = "pipewire-midi2")]
         if is_pipewire_midi_input_id(id) {
             {
                 let inputs = self.pipewire_inputs.lock().map_err(|e| {
@@ -286,6 +289,7 @@ impl<B: Backend> Midi for MidiHandler<B> {
     async fn close(&self, id: MidiDeviceId) -> Result<()> {
         let mut removed = false;
 
+        #[cfg(feature = "pipewire-midi2")]
         if self
             .pipewire_inputs
             .lock()

--- a/crates/vibelang-core/src/handlers/midi/trait_impl.rs
+++ b/crates/vibelang-core/src/handlers/midi/trait_impl.rs
@@ -4,13 +4,13 @@ use super::output::{detect_midi2_capability, send_midi2_event_to_device};
 use super::types::convert_new_to_legacy_message;
 use super::MidiHandler;
 use crate::backend::Backend;
+#[cfg(feature = "pipewire-midi2")]
+use crate::midi::open_pipewire_midi2_input;
 use crate::midi::{
     is_pipewire_midi_input_id, list_pipewire_midi2_inputs,
     parse_midi_bytes as new_parse_midi_bytes, MidiRecording, MidiRecordingInfo, QueuedMidiEvent,
     TimestampedMidiEvent,
 };
-#[cfg(feature = "pipewire-midi2")]
-use crate::midi::open_pipewire_midi2_input;
 use crate::traits::{Midi, MidiDeviceInfo, MidiOutputCapability};
 use crate::types::ids::MidiDeviceId;
 use crate::types::VoiceId;

--- a/crates/vibelang-core/src/midi/mod.rs
+++ b/crates/vibelang-core/src/midi/mod.rs
@@ -93,6 +93,7 @@ mod mpe;
 mod nrpn;
 mod parser;
 mod per_note_state;
+#[cfg(feature = "pipewire-midi2")]
 mod pipewire_input;
 mod queue;
 mod recording;
@@ -139,11 +140,38 @@ pub use clock::{MidiClock, MidiClockSync};
 // MIDI message parsing
 pub use parser::{parse_midi_bytes, MidiParser};
 
+#[cfg(feature = "pipewire-midi2")]
 pub use pipewire_input::{
     is_pipewire_midi_input_id, list_pipewire_midi2_inputs, open_pipewire_midi2_input,
     parse_pipewire_midi_pod, pipewire_midi_input_id, PipeWireMidiInputConnection,
     PipeWireMidiInputInfo, PIPEWIRE_MIDI_INPUT_FLAG,
 };
+
+/// Without the `pipewire-midi2` feature there are no PipeWire device ids, so
+/// nothing can ever match one. Kept unconditional so call sites stay free of
+/// `#[cfg]` noise.
+#[cfg(not(feature = "pipewire-midi2"))]
+#[inline]
+pub fn is_pipewire_midi_input_id(_id: crate::types::ids::MidiDeviceId) -> bool {
+    false
+}
+
+/// No PipeWire device ids exist without the feature.
+#[cfg(not(feature = "pipewire-midi2"))]
+#[inline]
+pub fn list_pipewire_midi2_inputs() -> Vec<PipeWireMidiInputInfo> {
+    Vec::new()
+}
+
+/// Placeholder device descriptor so `list_pipewire_midi2_inputs` has a return
+/// type without the feature. Field-compatible with the real one; never
+/// constructed, because the list is always empty.
+#[cfg(not(feature = "pipewire-midi2"))]
+pub struct PipeWireMidiInputInfo {
+    pub id: crate::types::ids::MidiDeviceId,
+    pub name: String,
+    pub target_object: String,
+}
 
 // MIDI message encoding
 pub use encoder::{


### PR DESCRIPTION
## Problem

`vibelang-core`'s `midi` feature implied `pipewire-midi2`:

```toml
midi = ["dep:midir", "pipewire-midi2"]
pipewire-midi2 = ["dep:libspa", "dep:pipewire"]
```

So *any* build with MIDI dragged in `libspa`/`pipewire` — native deps that can't cross-compile without a target pkg-config sysroot, and that don't exist on embedded Linux boards at all. MIDI via midir (ALSA / CoreMIDI / WinMM) has no such requirement, so an embedded target had to choose between "no MIDI" and "doesn't build".

Concretely: on a Bela Gem (PocketBeagle 2, aarch64, no PipeWire) the board build had to drop `midi` entirely, which meant `.vibe` scripts couldn't open MIDI devices and every controller needed an external bridge daemon translating to the HTTP API.

## Changes

- **vibelang-core**: `midi = ["dep:midir"]`; `pipewire-midi2` is now additive (`["midi", "dep:libspa", "dep:pipewire"]`). The `pipewire_input` module, its re-exports, the `MidiHandler::pipewire_inputs` field, and the open/close paths are feature-gated. Without the feature, `is_pipewire_midi_input_id` returns `false` and `list_pipewire_midi2_inputs` returns empty, so call sites stay free of `#[cfg]` noise.
- **vibelang-cli**: `pipewire-midi2` passthrough feature, kept in `default` — desktop builds are behaviourally identical.
- **Cross.toml**: installs target-arch ALSA headers (`libasound2-dev:arm64` / `:armhf`) and sets `PKG_CONFIG_*` so `midir`→`alsa-sys` cross-compiles.

## Verification

- Defaults unchanged: `cargo tree -i pipewire -p vibelang-cli` still resolves PipeWire; core features still `[midi,native,pipewire-midi2,rosc]`.
- `cargo check -p vibelang-core --no-default-features --features native,midi` — clean (previously impossible).
- `cargo test -p vibelang-core --lib midi` — 181 passed, both with defaults and with `native,midi`.
- Cross-built for `aarch64-unknown-linux-gnu` with `midi,api,lsp,extensions` and **running on hardware**: the `.vibe` script now enumerates devices and does its own routing —

```rhai
for d in list_midi_devices() { ... }              // finds the controller
dev.route_to_channel(1, note);                     // keyboard split
dev.map_cc(0).channel(2).curve("exp").to(note, "cutoff", 100.0, 8000.0);
```

```
Opened MIDI input: Gamma:Gamma MIDI 1 20:0 (id=2) with timestamp preservation
Applied 4 basic MIDI keyboard routes from script
Applied 12 advanced MIDI CC routes from script
```

Stacks with #8 (feature-flag hygiene) — both are needed for a working embedded build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)