### PR TITLE
fix(core): make structural reload teardown parent- and scheduler-safe

### DIFF
--- a/crates/vibelang-core/src/backend.rs
+++ b/crates/vibelang-core/src/backend.rs
@@ -177,6 +177,16 @@ pub trait Backend: Send + Sync + 'static {
     /// Works for both synths and groups.
     async fn free_node(&self, node: NodeId) -> Result<(), Self::Error>;
 
+    /// Return whether the backend has observed this node's definitive end.
+    ///
+    /// Backends with node-lifecycle notifications can use this to suppress a
+    /// stale teardown command after a synth has already freed itself. The
+    /// default is conservative: without definitive evidence, callers still
+    /// issue the free.
+    fn node_has_ended(&self, _node: NodeId) -> bool {
+        false
+    }
+
     /// Pause or resume a node.
     ///
     /// Paused nodes don't process audio but retain their state.
@@ -435,6 +445,11 @@ pub trait Backend: 'static {
 
     /// Free (destroy) a node.
     async fn free_node(&self, node: NodeId) -> Result<(), Self::Error>;
+
+    /// Return whether the backend has observed this node's definitive end.
+    fn node_has_ended(&self, _node: NodeId) -> bool {
+        false
+    }
 
     /// Pause or resume a node.
     async fn run_node(&self, node: NodeId, running: bool) -> Result<(), Self::Error>;

--- a/crates/vibelang-core/src/backends/scsynth.rs
+++ b/crates/vibelang-core/src/backends/scsynth.rs
@@ -18,7 +18,7 @@ use crate::backend::{AddAction, Backend, BufferInfo};
 use crate::types::{BufferId, NodeId, ParamMap};
 use async_trait::async_trait;
 use rosc::{decoder, encoder, OscBundle, OscMessage, OscPacket, OscTime, OscType};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io;
 use std::net::UdpSocket;
@@ -191,6 +191,9 @@ pub struct ScsynthBackend {
     next_sync_id: Arc<std::sync::atomic::AtomicI32>,
     /// General response callbacks.
     callbacks: Arc<Mutex<Vec<OscCallback>>>,
+    /// Node IDs for which scsynth has delivered a definitive `/n_end`.
+    /// Cleared before an ID is submitted for a new node generation.
+    ended_nodes: Arc<Mutex<HashSet<NodeId>>>,
     /// Server status (updated by listener).
     server_ready: Arc<AtomicBool>,
 }
@@ -236,6 +239,7 @@ impl ScsynthBackend {
         let pending_synthdef_load = Arc::new(Mutex::new(None));
         let next_sync_id = Arc::new(std::sync::atomic::AtomicI32::new(1));
         let callbacks = Arc::new(Mutex::new(Vec::new()));
+        let ended_nodes = Arc::new(Mutex::new(HashSet::new()));
 
         let socket = Arc::new(socket);
 
@@ -251,8 +255,27 @@ impl ScsynthBackend {
             pending_synthdef_load: pending_synthdef_load.clone(),
             next_sync_id,
             callbacks: callbacks.clone(),
+            ended_nodes: ended_nodes.clone(),
             server_ready: server_ready.clone(),
         };
+
+        // Record lifecycle notifications independently of the best-effort
+        // State callback installed by the CLI. Voice teardown consults this
+        // set before sending a fallback /n_free, so a contended State lock
+        // cannot turn an already-observed /n_end into a server-side failure.
+        backend.on_response(Arc::new(move |response| match response {
+            OscResponse::NodeEnd { node_id, .. } => {
+                if let Ok(mut ended) = ended_nodes.lock() {
+                    ended.insert(node_id);
+                }
+            }
+            OscResponse::NodeGo { node_id, .. } => {
+                if let Ok(mut ended) = ended_nodes.lock() {
+                    ended.remove(&node_id);
+                }
+            }
+            _ => {}
+        }));
 
         // Start OSC listener thread
         Self::start_listener(
@@ -1078,6 +1101,12 @@ impl ScsynthBackend {
         }
     }
 
+    fn prepare_node_generation(&self, node: NodeId) {
+        if let Ok(mut ended) = self.ended_nodes.lock() {
+            ended.remove(&node);
+        }
+    }
+
     /// Request buffer info and wait for response.
     pub async fn query_buffer_info(&self, id: BufferId) -> Result<BufferInfo, ScsynthError> {
         // Create oneshot channel for response
@@ -1262,6 +1291,7 @@ impl Backend for ScsynthBackend {
         action: AddAction,
         params: &ParamMap,
     ) -> Result<(), Self::Error> {
+        self.prepare_node_generation(node);
         tracing::debug!(
             "s_new: def='{}', node={}, target={}, params={:?}",
             def,
@@ -1287,6 +1317,7 @@ impl Backend for ScsynthBackend {
         param_buses: &[(String, u32)],
         at: Option<Instant>,
     ) -> Result<(), Self::Error> {
+        self.prepare_node_generation(node);
         tracing::debug!(
             "s_new (scheduled): def='{}', node={}, target={}, at={:?}, params={:?}",
             def,
@@ -1320,6 +1351,7 @@ impl Backend for ScsynthBackend {
         target: NodeId,
         action: AddAction,
     ) -> Result<(), Self::Error> {
+        self.prepare_node_generation(node);
         self.send_msg(
             "/g_new",
             vec![
@@ -1332,8 +1364,22 @@ impl Backend for ScsynthBackend {
     }
 
     async fn free_node(&self, node: NodeId) -> Result<(), Self::Error> {
+        if self.node_has_ended(node) {
+            tracing::debug!(
+                "Skipping /n_free for node {} after definitive /n_end",
+                node.0
+            );
+            return Ok(());
+        }
         self.send_msg("/n_free", vec![OscType::Int(node.0 as i32)])?;
         Ok(())
+    }
+
+    fn node_has_ended(&self, node: NodeId) -> bool {
+        self.ended_nodes
+            .lock()
+            .map(|ended| ended.contains(&node))
+            .unwrap_or(false)
     }
 
     async fn run_node(&self, node: NodeId, running: bool) -> Result<(), Self::Error> {

--- a/crates/vibelang-core/src/handlers/effects.rs
+++ b/crates/vibelang-core/src/handlers/effects.rs
@@ -21,7 +21,7 @@ use crate::compat::Duration;
 
 /// Grace period before freeing an effect node (in milliseconds).
 /// This allows time for the mix parameter to fade to 0.
-const EFFECT_GRACE_PERIOD_MS: u64 = 50;
+pub(crate) const EFFECT_GRACE_PERIOD_MS: u64 = 50;
 
 /// Handler for effect operations.
 pub struct EffectsHandler<B: Backend> {

--- a/crates/vibelang-core/src/handlers/groups.rs
+++ b/crates/vibelang-core/src/handlers/groups.rs
@@ -113,17 +113,6 @@ impl<B: Backend> GroupsHandler<B> {
         let group = {
             let mut state = self.state.write().await;
             let group = state.groups.remove(&id).ok_or(Error::GroupNotFound(id))?;
-            if immediate {
-                // Immediate path: nodes are /n_free'd below in this same
-                // call, so IDs and the bus are definitively done.
-                state.free_node_id(group.node_id);
-                if let Some(link_id) = group.link_synth_node_id {
-                    state.free_node_id(link_id);
-                }
-                // Return the group's stereo audio bus to the free pool so
-                // long-running sessions don't burn through bus IDs.
-                state.free_audio_bus(group.audio_bus, 2);
-            }
             // Drop the live chain-order tracking; a recreated group with the
             // same id starts a fresh chain.
             state.group_effect_chain.remove(&id);
@@ -141,6 +130,16 @@ impl<B: Backend> GroupsHandler<B> {
                 .free_node(group.node_id)
                 .await
                 .map_err(Error::backend)?;
+
+            // Keep IDs and the bus owned until every backend free above has
+            // been sent. Reclaiming them before /n_free lets a same-pass
+            // create reuse an ID or bus while the old subtree still exists.
+            let mut state = self.state.write().await;
+            state.free_node_id(group.node_id);
+            if let Some(link_id) = group.link_synth_node_id {
+                state.free_node_id(link_id);
+            }
+            state.free_audio_bus(group.audio_bus, 2);
 
             tracing::debug!("Deleted group {} (node_id={})", id.0, group.node_id.0);
             return Ok(());

--- a/crates/vibelang-core/src/handlers/melodies.rs
+++ b/crates/vibelang-core/src/handlers/melodies.rs
@@ -26,7 +26,7 @@ use std::time::Duration;
 /// - Short enough to respond to transport stops quickly
 /// - At 120 BPM: 0.1 beats of lookahead
 /// - At 180 BPM: 0.15 beats of lookahead
-const LOOKAHEAD_MS: u64 = 50;
+pub(crate) const LOOKAHEAD_MS: u64 = 50;
 
 /// Tracks pending note-off: (voice_id, note) -> (beat, wall-clock timestamp)
 ///

--- a/crates/vibelang-core/src/handlers/mod.rs
+++ b/crates/vibelang-core/src/handlers/mod.rs
@@ -85,10 +85,13 @@ mod recordings;
 mod midi;
 
 pub use effects::EffectsHandler;
+pub(crate) use effects::EFFECT_GRACE_PERIOD_MS;
 pub use fades::FadesHandler;
 pub use groups::GroupsHandler;
 pub use melodies::MelodiesHandler;
+pub(crate) use melodies::LOOKAHEAD_MS as MELODY_LOOKAHEAD_MS;
 pub use patterns::PatternsHandler;
+pub(crate) use patterns::LOOKAHEAD_MS as PATTERN_LOOKAHEAD_MS;
 pub use routes::{
     compute_input_route_diff, default_routes_for_voice, merge_default_routes, InputRoute,
     InputRouteDiff, InputRouteMap, InputRouteSrc, ParamRoute, ParamRouteDiff, ParamRouteMap,

--- a/crates/vibelang-core/src/handlers/patterns.rs
+++ b/crates/vibelang-core/src/handlers/patterns.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 /// Matches the melody lookahead for consistent timing behavior.
 /// Notes within this window ahead of the current beat are scheduled with
 /// precise wall-clock timestamps.
-const LOOKAHEAD_MS: u64 = 50;
+pub(crate) const LOOKAHEAD_MS: u64 = 50;
 
 /// Resolve the absolute scheduling window `[w_from, w_to)` for this tick.
 ///

--- a/crates/vibelang-core/src/handlers/voices.rs
+++ b/crates/vibelang-core/src/handlers/voices.rs
@@ -1202,28 +1202,30 @@ impl<B: Backend> Voices for VoicesHandler<B> {
     async fn delete(&self, id: VoiceId) -> Result<()> {
         let detached = {
             let mut state = self.state.write().await;
-            let detached = detach_voice(&mut state, id)?;
-            // Hard delete: every node is explicitly /n_free'd below, so the
-            // IDs are definitively done and safe to recycle right away; the
-            // buses go back to the allocators in the same breath.
-            reclaim_detached_now(&mut state, &detached);
-            detached
+            detach_voice(&mut state, id)?
         };
 
-        // Release any still-sounding pool notes on the external device.
-        #[cfg(feature = "midi")]
-        self.flush_pool_cleanup(detached.pool_cleanup).await;
-
         // Free all active synth nodes (lock released)
-        for node_id in detached.nodes {
-            let _ = self.backend.free_node(node_id).await;
+        for node_id in &detached.nodes {
+            let _ = self.backend.free_node(*node_id).await;
         }
         // Free per-port route mixer synths so they no longer read from the
         // voice's freed audio bus (avoids stale `In.ar` reads when the bus
         // is recycled to a later voice).
-        for node_id in detached.route_nodes {
-            let _ = self.backend.free_node(node_id).await;
+        for node_id in &detached.route_nodes {
+            let _ = self.backend.free_node(*node_id).await;
         }
+
+        // The backend teardown is now definitive; only now may the allocator
+        // hand these node IDs and buses to a replacement voice.
+        {
+            let mut state = self.state.write().await;
+            reclaim_detached_now(&mut state, &detached);
+        }
+
+        // Release any still-sounding pool notes on the external device.
+        #[cfg(feature = "midi")]
+        self.flush_pool_cleanup(detached.pool_cleanup).await;
 
         Ok(())
     }
@@ -1235,25 +1237,28 @@ impl<B: Backend> Voices for VoicesHandler<B> {
             // Only gated voices with sounding nodes need the deferred path;
             // everything else reclaims immediately, exactly like `delete`.
             let defer = detached.gated && !detached.nodes.is_empty();
-            if !defer {
-                reclaim_detached_now(&mut state, &detached);
-            }
             (detached, defer)
         };
+
+        if !defer {
+            for node_id in &detached.nodes {
+                let _ = self.backend.free_node(*node_id).await;
+            }
+            for node_id in &detached.route_nodes {
+                let _ = self.backend.free_node(*node_id).await;
+            }
+            {
+                let mut state = self.state.write().await;
+                reclaim_detached_now(&mut state, &detached);
+            }
+            #[cfg(feature = "midi")]
+            self.flush_pool_cleanup(detached.pool_cleanup).await;
+            return Ok(());
+        }
 
         // Release any still-sounding pool notes on the external device.
         #[cfg(feature = "midi")]
         self.flush_pool_cleanup(detached.pool_cleanup).await;
-
-        if !defer {
-            for node_id in detached.nodes {
-                let _ = self.backend.free_node(node_id).await;
-            }
-            for node_id in detached.route_nodes {
-                let _ = self.backend.free_node(node_id).await;
-            }
-            return Ok(());
-        }
 
         // Set gate=0 on all active synth nodes to trigger release envelopes.
         // The synths free themselves via doneAction=2 when the envelope

--- a/crates/vibelang-core/src/handlers/voices.rs
+++ b/crates/vibelang-core/src/handlers/voices.rs
@@ -101,10 +101,10 @@ pub(crate) fn voice_release_grace(config: &VoiceConfig) -> Duration {
 /// are therefore NOT recycled at release time (a recycled ID could be handed
 /// to a new synth while the old node still exists — commit 8ca4fed's
 /// discipline). Instead each release stashes one of these entries; after
-/// `grace` the tick loop sends a fallback `/n_free` (a no-op "Node not
-/// found" if the node already self-freed, which the backend tolerates) and
-/// only then recycles IDs and returns buses to their allocators, so a bus
-/// can never be reallocated while a released node is still sounding into it.
+/// `grace` the tick loop skips the fallback when the backend has observed a
+/// definitive node end, otherwise sends `/n_free`; only then does it recycle
+/// IDs and return buses to their allocators, so a bus can never be reallocated
+/// while a released node is still sounding into it.
 struct PendingVoiceReclaim {
     /// When the release was requested (or, for scheduled note steals, the
     /// scheduled sounding time).
@@ -145,6 +145,21 @@ impl<B: Backend> VoicesHandler<B> {
         }
     }
 
+    async fn free_node_if_live(&self, node: NodeId) {
+        if self.backend.node_has_ended(node) {
+            tracing::debug!(
+                "Voice reclaim: node {:?} already ended; skipping fallback free",
+                node
+            );
+            return;
+        }
+        tracing::debug!(
+            "Voice reclaim: grace elapsed, fallback-freeing node {:?}",
+            node
+        );
+        let _ = self.backend.free_node(node).await;
+    }
+
     /// Process pending voice reclaims whose grace period has elapsed.
     ///
     /// Called by the runtime's tick loop (same idiom as
@@ -178,15 +193,11 @@ impl<B: Backend> VoicesHandler<B> {
 
         for entry in due {
             for node in entry.released_nodes.iter().chain(entry.route_nodes.iter()) {
-                tracing::debug!(
-                    "Voice reclaim: grace elapsed, fallback-freeing node {:?}",
-                    node
-                );
-                let _ = self.backend.free_node(*node).await;
+                self.free_node_if_live(*node).await;
             }
             let mut state = self.state.write().await;
-            // The /n_free above has been sent, so the IDs are definitively
-            // dead and safe to recycle now.
+            // Every node above either had a definitive backend end or was
+            // fallback-freed, so the IDs are now safe to recycle.
             for node in entry.released_nodes.iter().chain(entry.route_nodes.iter()) {
                 state.free_node_id(*node);
             }
@@ -896,7 +907,7 @@ impl<B: Backend> VoicesHandler<B> {
                 })
                 .await;
             } else {
-                let _ = self.backend.free_node(old).await;
+                self.free_node_if_live(old).await;
             }
         }
 
@@ -1207,13 +1218,13 @@ impl<B: Backend> Voices for VoicesHandler<B> {
 
         // Free all active synth nodes (lock released)
         for node_id in &detached.nodes {
-            let _ = self.backend.free_node(*node_id).await;
+            self.free_node_if_live(*node_id).await;
         }
         // Free per-port route mixer synths so they no longer read from the
         // voice's freed audio bus (avoids stale `In.ar` reads when the bus
         // is recycled to a later voice).
         for node_id in &detached.route_nodes {
-            let _ = self.backend.free_node(*node_id).await;
+            self.free_node_if_live(*node_id).await;
         }
 
         // The backend teardown is now definitive; only now may the allocator
@@ -1242,10 +1253,10 @@ impl<B: Backend> Voices for VoicesHandler<B> {
 
         if !defer {
             for node_id in &detached.nodes {
-                let _ = self.backend.free_node(*node_id).await;
+                self.free_node_if_live(*node_id).await;
             }
             for node_id in &detached.route_nodes {
-                let _ = self.backend.free_node(*node_id).await;
+                self.free_node_if_live(*node_id).await;
             }
             {
                 let mut state = self.state.write().await;
@@ -1482,7 +1493,7 @@ impl<B: Backend> Voices for VoicesHandler<B> {
         // then. Gated chokes are scheduled at the trigger time so the choke
         // lands exactly when the new note sounds.
         for choke_node in choke_free {
-            let _ = self.backend.free_node(choke_node).await;
+            self.free_node_if_live(choke_node).await;
         }
         for (grace, nodes) in choke_release {
             for node in &nodes {
@@ -1540,7 +1551,7 @@ impl<B: Backend> Voices for VoicesHandler<B> {
             }
         } else {
             for old_node in old_nodes {
-                let _ = self.backend.free_node(old_node).await;
+                self.free_node_if_live(old_node).await;
             }
         }
 
@@ -1618,7 +1629,7 @@ impl<B: Backend> Voices for VoicesHandler<B> {
             .await;
         } else {
             for node_id in nodes {
-                let _ = self.backend.free_node(node_id).await;
+                self.free_node_if_live(node_id).await;
             }
         }
 

--- a/crates/vibelang-core/src/runtime.rs
+++ b/crates/vibelang-core/src/runtime.rs
@@ -997,6 +997,37 @@ impl<B: Backend> Runtime<B> {
         ids
     }
 
+    async fn structurally_recreated_effect_ids(
+        &self,
+        diff: &reload::ReloadDiff,
+        new_state: &reload::ScriptState,
+    ) -> Vec<crate::types::EffectId> {
+        let state = self.state.read().await;
+        let mut ids: Vec<_> = diff
+            .effects
+            .updated
+            .iter()
+            .filter_map(|(id, new_config)| {
+                let current = state.effects.get(id)?;
+                (current.synthdef != new_config.synthdef
+                    || current.group != new_config.group
+                    || reload::synthdef_body_changed(&state, new_state, &new_config.synthdef))
+                .then_some(*id)
+            })
+            .collect();
+        ids.sort_by_key(|id| {
+            (
+                new_state
+                    .effect_order
+                    .iter()
+                    .position(|ordered| ordered == id)
+                    .unwrap_or(usize::MAX),
+                id.raw(),
+            )
+        });
+        ids
+    }
+
     fn push_param_route_once(routes: &mut Vec<ParamRoute>, route: ParamRoute) {
         if !routes.contains(&route) {
             routes.push(route);
@@ -1425,14 +1456,39 @@ impl<B: Backend> Runtime<B> {
 
         tracing::info!("Reload: applying changes");
 
+        let structurally_recreated_voices = self
+            .structurally_recreated_voice_ids(&diff, &new_state)
+            .await;
+        let structurally_recreated_effects = self
+            .structurally_recreated_effect_ids(&diff, &new_state)
+            .await;
+        let group_teardown_grace = self
+            .reload_group_teardown_grace(
+                &diff,
+                &structurally_recreated_voices,
+                &structurally_recreated_effects,
+            )
+            .await;
+
         self.phase_apply_transport_changes(&diff).await?;
+        self.phase_quiesce_and_drain_schedulers(&diff, &structurally_recreated_voices)
+            .await;
         self.phase_stop_deleted_entities(&diff).await;
-        self.phase_delete_entities(&diff).await;
+        // Replacement parents must exist before same-ID voices move out of
+        // groups that this reload is about to destroy.
+        self.phase_create_groups(&diff).await;
+        self.phase_recreate_structural_voices(&diff, &structurally_recreated_voices)
+            .await;
+        self.phase_remove_structural_effects(&structurally_recreated_effects)
+            .await;
+        self.phase_delete_entities(&diff, group_teardown_grace)
+            .await;
         if !self.phase_open_midi_devices(&new_state).await? {
             return Ok(());
         }
         self.phase_create_entities(&diff, &new_state, staged).await;
-        self.phase_update_entities(&diff, &new_state).await;
+        self.phase_update_entities(&diff, &new_state, &structurally_recreated_voices)
+            .await;
         self.phase_finalize_output_routes(&diff).await?;
         self.phase_finalize_input_routes(&input_routes).await?;
         self.phase_apply_effects(&diff, &new_state).await;
@@ -1630,6 +1686,138 @@ impl<B: Backend> Runtime<B> {
         Ok(())
     }
 
+    /// Stop affected lookahead schedulers from dispatching, then leave enough
+    /// wall-clock time for every already-sent timed bundle to execute while
+    /// its original voice and parent group still exist.
+    async fn phase_quiesce_and_drain_schedulers(
+        &mut self,
+        diff: &reload::ReloadDiff,
+        structurally_recreated_voices: &[VoiceId],
+    ) {
+        let should_drain = {
+            let mut state = self.state.write().await;
+            let mut affected_voices: std::collections::HashSet<VoiceId> = diff
+                .voices
+                .deleted
+                .iter()
+                .copied()
+                .chain(structurally_recreated_voices.iter().copied())
+                .collect();
+            for (id, voice) in &state.voices {
+                if diff.groups.deleted.contains(&voice.config.group) {
+                    affected_voices.insert(*id);
+                }
+            }
+
+            let mut drain = false;
+            for (id, pattern) in &mut state.patterns {
+                let affected = diff.patterns.deleted.contains(id)
+                    || pattern
+                        .content
+                        .voice
+                        .is_some_and(|voice| affected_voices.contains(&voice));
+                if affected {
+                    drain |= pattern.scheduled_until.is_some();
+                    pattern.playing = false;
+                }
+            }
+            for (id, melody) in &mut state.melodies {
+                let affected = diff.melodies.deleted.contains(id)
+                    || melody
+                        .content
+                        .voice
+                        .is_some_and(|voice| affected_voices.contains(&voice));
+                if affected {
+                    drain |= melody.scheduled_until.is_some();
+                    melody.playing = false;
+                }
+            }
+            drain
+        };
+
+        if should_drain {
+            const SCHEDULER_DRAIN_MARGIN_MS: u64 = 5;
+            let lookahead_ms =
+                crate::handlers::PATTERN_LOOKAHEAD_MS.max(crate::handlers::MELODY_LOOKAHEAD_MS);
+            let drain =
+                crate::compat::Duration::from_millis(lookahead_ms + SCHEDULER_DRAIN_MARGIN_MS);
+            tracing::debug!(
+                "Reload: draining previously dispatched scheduler bundles for {:?}",
+                drain
+            );
+            crate::compat::sleep(drain).await;
+            self.sync_with_retry("after scheduler lookahead drain")
+                .await;
+        }
+    }
+
+    /// Longest child-removal deadline that a deleted group must outlive.
+    /// This is captured before structural reconciliation detaches the old
+    /// voice/effect state from the maps used to derive it.
+    async fn reload_group_teardown_grace(
+        &self,
+        diff: &reload::ReloadDiff,
+        structurally_recreated_voices: &[VoiceId],
+        structurally_recreated_effects: &[crate::types::EffectId],
+    ) -> crate::compat::Duration {
+        if diff.groups.deleted.is_empty() {
+            return crate::compat::Duration::ZERO;
+        }
+
+        let state = self.state.read().await;
+        let mut grace = crate::compat::Duration::ZERO;
+        for id in diff
+            .voices
+            .deleted
+            .iter()
+            .chain(structurally_recreated_voices.iter())
+        {
+            if let Some(voice) = state.voices.get(id) {
+                let sounding = !voice.active_nodes.is_empty() || !voice.note_nodes.is_empty();
+                if sounding && crate::handlers::voice_is_gated(&voice.config) {
+                    grace = grace.max(crate::handlers::voice_release_grace(&voice.config));
+                }
+            }
+        }
+        if !diff.effects.deleted.is_empty() || !structurally_recreated_effects.is_empty() {
+            grace = grace.max(crate::compat::Duration::from_millis(
+                crate::handlers::EFFECT_GRACE_PERIOD_MS,
+            ));
+        }
+        grace
+    }
+
+    async fn phase_recreate_structural_voices(
+        &mut self,
+        diff: &reload::ReloadDiff,
+        ids: &[VoiceId],
+    ) {
+        for id in ids {
+            let Some(config) = diff.voices.updated.get(id) else {
+                continue;
+            };
+            tracing::debug!(
+                "Reload: recreating voice {:?} before old-parent teardown",
+                id
+            );
+            if let Err(e) = self.voices.recreate(*id, config.clone()).await {
+                tracing::error!("Reload: failed to recreate voice {:?}: {}", id, e);
+            }
+        }
+    }
+
+    async fn phase_remove_structural_effects(&mut self, ids: &[crate::types::EffectId]) {
+        for id in ids {
+            tracing::debug!(
+                "Reload: detaching effect {:?} before old-parent teardown",
+                id
+            );
+            if let Err(e) = self.effects.remove(*id).await {
+                tracing::warn!("Reload: failed to detach effect {:?}: {}", id, e);
+            }
+        }
+    }
+
     /// Stops or cancels runtime activity for entities that are about to be removed or restarted.
     async fn phase_stop_deleted_entities(&mut self, diff: &reload::ReloadDiff) {
         // NOTE: We NO LONGER stop patterns/melodies that are being updated.
@@ -1680,7 +1868,11 @@ impl<B: Backend> Runtime<B> {
     }
 
     /// Removes deleted runtime entities and frees script-owned resources.
-    async fn phase_delete_entities(&mut self, diff: &reload::ReloadDiff) {
+    async fn phase_delete_entities(
+        &mut self,
+        diff: &reload::ReloadDiff,
+        group_teardown_grace: crate::compat::Duration,
+    ) {
         // Delete effects (they depend on groups)
         for id in &diff.effects.deleted {
             tracing::debug!("Reload: deleting effect {:?}", id);
@@ -1713,30 +1905,6 @@ impl<B: Backend> Runtime<B> {
             tracing::debug!("Reload: deleting sequence {:?}", id);
             let _ = self.sequences.delete(*id).await;
         }
-
-        // Compute the group-teardown grace BEFORE deleting the voices:
-        // group nodes must outlive the release tails of every voice node
-        // that is gate-released in this reload pass (deleted voices below,
-        // plus structurally-recreated voices in phase_update_entities whose
-        // old nodes sit inside a group deleted here).
-        let group_teardown_grace = {
-            let state = self.state.read().await;
-            let mut grace = crate::compat::Duration::ZERO;
-            let deleted = diff.voices.deleted.iter();
-            let recreated = diff.voices.updated.iter().filter_map(|(id, new_config)| {
-                let current = state.voices.get(id)?;
-                Self::voice_needs_structural_recreate(&current.config, new_config).then_some(id)
-            });
-            for id in deleted.chain(recreated) {
-                if let Some(voice) = state.voices.get(id) {
-                    let sounding = !voice.active_nodes.is_empty() || !voice.note_nodes.is_empty();
-                    if sounding && crate::handlers::voice_is_gated(&voice.config) {
-                        grace = grace.max(crate::handlers::voice_release_grace(&voice.config));
-                    }
-                }
-            }
-            grace
-        };
 
         // Delete voices (before groups they belong to). Graceful: sounding
         // gated nodes get gate=0 and tail out via their release envelope;
@@ -1993,7 +2161,70 @@ impl<B: Backend> Runtime<B> {
         Ok(true)
     }
 
-    /// Creates new samples, buffers, groups, voices, patterns, melodies, sequences, and SFZ instruments.
+    /// Creates replacement parent groups before any same-ID voice is moved
+    /// out of an old group that this reload will destroy.
+    async fn phase_create_groups(&mut self, diff: &reload::ReloadDiff) {
+        let ordered_group_creations = reload::order_group_creations(&diff.groups.created);
+        for id in ordered_group_creations {
+            if let Some(config) = diff.groups.created.get(&id) {
+                tracing::debug!("Reload: creating group {:?}", id);
+                if let Err(e) = self.groups.create(id, &config.name, config.parent).await {
+                    tracing::error!(
+                        "Reload: failed to create group {:?} '{}': {}",
+                        id,
+                        config.name,
+                        e
+                    );
+                    continue;
+                }
+                for (param, value) in &config.params {
+                    if let Err(e) = self.groups.set_param(id, param, *value).await {
+                        tracing::warn!(
+                            "Reload: failed to set initial param '{}'={} on group {:?} '{}': {}",
+                            param,
+                            value,
+                            id,
+                            config.name,
+                            e
+                        );
+                    }
+                }
+                if config.muted {
+                    if let Err(e) = self.groups.mute(id, true).await {
+                        tracing::warn!(
+                            "Reload: failed to mute group {:?} '{}': {}",
+                            id,
+                            config.name,
+                            e
+                        );
+                    }
+                }
+                if config.soloed {
+                    if let Err(e) = self.groups.solo(id, true).await {
+                        tracing::warn!(
+                            "Reload: failed to solo group {:?} '{}': {}",
+                            id,
+                            config.name,
+                            e
+                        );
+                    }
+                }
+                if config.output_bus.is_some() {
+                    let mut state = self.state.write().await;
+                    if let Some(group) = state.groups.get_mut(&id) {
+                        group.output_bus = config.output_bus;
+                        group.output_channels = config.output_channels;
+                    }
+                }
+            }
+        }
+
+        if !diff.groups.created.is_empty() {
+            self.sync_with_retry("after group creation").await;
+        }
+    }
+
+    /// Creates new samples, buffers, voices, patterns, melodies, sequences, and SFZ instruments.
     async fn phase_create_entities(
         &mut self,
         diff: &reload::ReloadDiff,
@@ -2126,73 +2357,6 @@ impl<B: Backend> Runtime<B> {
             }
         }
 
-        // Create groups in correct order (parents first)
-        let ordered_group_creations = reload::order_group_creations(&diff.groups.created);
-        for id in ordered_group_creations {
-            if let Some(config) = diff.groups.created.get(&id) {
-                tracing::debug!("Reload: creating group {:?}", id);
-                if let Err(e) = self.groups.create(id, &config.name, config.parent).await {
-                    tracing::error!(
-                        "Reload: failed to create group {:?} '{}': {}",
-                        id,
-                        config.name,
-                        e
-                    );
-                    continue;
-                }
-                // Apply initial params
-                for (param, value) in &config.params {
-                    if let Err(e) = self.groups.set_param(id, param, *value).await {
-                        tracing::warn!(
-                            "Reload: failed to set initial param '{}'={} on group {:?} '{}': {}",
-                            param,
-                            value,
-                            id,
-                            config.name,
-                            e
-                        );
-                    }
-                }
-                // Apply initial mute/solo state
-                if config.muted {
-                    if let Err(e) = self.groups.mute(id, true).await {
-                        tracing::warn!(
-                            "Reload: failed to mute group {:?} '{}': {}",
-                            id,
-                            config.name,
-                            e
-                        );
-                    }
-                }
-                if config.soloed {
-                    if let Err(e) = self.groups.solo(id, true).await {
-                        tracing::warn!(
-                            "Reload: failed to solo group {:?} '{}': {}",
-                            id,
-                            config.name,
-                            e
-                        );
-                    }
-                }
-                // Apply output_bus / output_channels routing override.
-                // The two fields are coupled (both Some(_) or both None);
-                // mirror them together so the link-synth dispatch in
-                // `GroupsHandler::finalize` sees a consistent pair.
-                if config.output_bus.is_some() {
-                    let mut state = self.state.write().await;
-                    if let Some(group) = state.groups.get_mut(&id) {
-                        group.output_bus = config.output_bus;
-                        group.output_channels = config.output_channels;
-                    }
-                }
-            }
-        }
-
-        // Sync with backend to ensure groups are created before we create synths targeting them
-        if !diff.groups.created.is_empty() {
-            self.sync_with_retry("after group creation").await;
-        }
-
         // Create new voices in merged script evaluation order. Repeated
         // group bodies contribute to one ScriptState, so this is the order the
         // Rhai layer recorded after all body/include merging.
@@ -2251,6 +2415,7 @@ impl<B: Backend> Runtime<B> {
         &mut self,
         diff: &reload::ReloadDiff,
         new_state: &reload::ScriptState,
+        structurally_recreated_voices: &[VoiceId],
     ) {
         // Update groups (params and mute/solo, parent changes not supported during reload).
         //
@@ -2417,9 +2582,6 @@ impl<B: Backend> Runtime<B> {
                         group.output_bus = new_config.output_bus;
                         group.output_channels = new_config.output_channels;
                         let teardown = group.link_synth_node_id.take();
-                        if let Some(node) = teardown {
-                            state.free_node_id(node);
-                        }
                         tracing::info!(
                             "Reload: group {:?} routing changed (bus {:?} -> {:?}, channels {:?} -> {:?}); link will be respawned by finalize",
                             id,
@@ -2438,6 +2600,7 @@ impl<B: Backend> Runtime<B> {
             };
             if let Some(node) = teardown_link_node {
                 let _ = self.backend.free_node(node).await;
+                self.state.write().await.free_node_id(node);
             }
         }
 
@@ -2464,6 +2627,9 @@ impl<B: Backend> Runtime<B> {
             )
         });
         for id in updated_voice_ids {
+            if structurally_recreated_voices.contains(&id) {
+                continue;
+            }
             let Some(new_config) = diff.voices.updated.get(&id) else {
                 continue;
             };
@@ -3555,7 +3721,7 @@ mod tests {
     use crate::handlers::RouteDest;
     use crate::reload::ParamRouteKind;
     use crate::state::GroupState;
-    use crate::types::{BufferId, BusId, GroupId, NodeId, ParamMap, VoiceId};
+    use crate::types::{Beat, BufferId, BusId, GroupId, NodeId, ParamMap, VoiceId};
     use std::collections::HashMap;
     use std::path::Path;
     use std::sync::{Arc, Mutex};
@@ -4811,6 +4977,92 @@ mod tests {
     /// synthdef name, target node, add action, and `in_bus`/`out_bus`/
     /// `__fx_bus_in` params (the routing-relevant ones). Tests assert against
     /// this transcript to prove the post-mix invariant.
+    #[derive(Clone)]
+    struct ScheduledSynth {
+        def: String,
+        node: NodeId,
+        target: NodeId,
+        action: AddAction,
+        params: ParamMap,
+        param_buses: Vec<(String, u32)>,
+        at: Instant,
+    }
+
+    #[derive(Clone)]
+    struct ModeledNode {
+        parent: Option<NodeId>,
+        def: Option<String>,
+        is_group: bool,
+    }
+
+    struct FaithfulGraph {
+        nodes: HashMap<NodeId, ModeledNode>,
+        scheduled: Vec<ScheduledSynth>,
+        violations: Vec<String>,
+        timed_executions: usize,
+    }
+
+    impl FaithfulGraph {
+        fn new() -> Self {
+            Self {
+                nodes: HashMap::from([(
+                    NodeId::new(0),
+                    ModeledNode {
+                        parent: None,
+                        def: None,
+                        is_group: true,
+                    },
+                )]),
+                scheduled: Vec::new(),
+                violations: Vec::new(),
+                timed_executions: 0,
+            }
+        }
+
+        fn parent_for_create(&mut self, target: NodeId, action: AddAction) -> Option<NodeId> {
+            let Some(target_node) = self.nodes.get(&target) else {
+                self.violations
+                    .push(format!("spawn targeted absent node {}", target.raw()));
+                return None;
+            };
+            match action {
+                AddAction::Head | AddAction::Tail => {
+                    if !target_node.is_group {
+                        self.violations
+                            .push(format!("spawn targeted non-group node {}", target.raw()));
+                        None
+                    } else {
+                        Some(target)
+                    }
+                }
+                AddAction::Before | AddAction::After => target_node.parent,
+                AddAction::Replace => target_node.parent,
+            }
+        }
+
+        fn remove_recursive(&mut self, node: NodeId) -> Vec<NodeId> {
+            if !self.nodes.contains_key(&node) {
+                self.violations
+                    .push(format!("duplicate free of absent node {}", node.raw()));
+                return Vec::new();
+            }
+            let mut removed = Vec::new();
+            let mut stack = vec![node];
+            while let Some(parent) = stack.pop() {
+                let children: Vec<_> = self
+                    .nodes
+                    .iter()
+                    .filter_map(|(id, child)| (child.parent == Some(parent)).then_some(*id))
+                    .collect();
+                stack.extend(children);
+                if self.nodes.remove(&parent).is_some() {
+                    removed.push(parent);
+                }
+            }
+            removed
+        }
+    }
+
     struct RecordingBackend {
         create_synth_log: std::sync::Mutex<Vec<RecordedSynth>>,
         create_group_log: std::sync::Mutex<Vec<NodeId>>,
@@ -4821,6 +5073,7 @@ mod tests {
         /// node N after free+respawn" even when the ID pool recycles a freed
         /// id back into the next create.
         events: std::sync::Mutex<Vec<BackendEvent>>,
+        faithful_graph: Option<Arc<std::sync::Mutex<FaithfulGraph>>>,
     }
 
     #[derive(Clone, Debug)]
@@ -4867,7 +5120,135 @@ mod tests {
                 free_node_log: std::sync::Mutex::new(Vec::new()),
                 map_param_log: std::sync::Mutex::new(Vec::new()),
                 events: std::sync::Mutex::new(Vec::new()),
+                faithful_graph: None,
             }
+        }
+
+        fn faithful() -> Self {
+            Self {
+                faithful_graph: Some(Arc::new(std::sync::Mutex::new(FaithfulGraph::new()))),
+                ..Self::new()
+            }
+        }
+
+        fn record_synth(
+            &self,
+            def: &str,
+            node: NodeId,
+            target: NodeId,
+            action: AddAction,
+            params: &ParamMap,
+        ) {
+            let link_outbus = params.get("outbus").copied();
+            self.create_synth_log.lock().unwrap().push(RecordedSynth {
+                def: def.to_string(),
+                node,
+                target,
+                action,
+                in_bus: params.get("in_bus").copied(),
+                out_bus: params.get("out_bus").copied(),
+                fx_bus_in: params.get("__fx_bus_in").copied(),
+                fx_bus_out: params.get("__fx_bus_out").copied(),
+                link_outbus,
+                params: params.clone(),
+            });
+            self.events.lock().unwrap().push(BackendEvent::Create {
+                def: def.to_string(),
+                node,
+                link_outbus,
+            });
+        }
+
+        fn insert_modeled_synth(
+            &self,
+            def: &str,
+            node: NodeId,
+            target: NodeId,
+            action: AddAction,
+            params: &ParamMap,
+        ) {
+            if let Some(graph) = &self.faithful_graph {
+                let mut graph = graph.lock().unwrap();
+                let Some(parent) = graph.parent_for_create(target, action) else {
+                    return;
+                };
+                if graph.nodes.contains_key(&node) {
+                    graph
+                        .violations
+                        .push(format!("spawn reused live node {}", node.raw()));
+                    return;
+                }
+                graph.nodes.insert(
+                    node,
+                    ModeledNode {
+                        parent: Some(parent),
+                        def: Some(def.to_string()),
+                        is_group: false,
+                    },
+                );
+            }
+            self.record_synth(def, node, target, action, params);
+        }
+
+        fn execute_due(&self) {
+            let Some(graph) = &self.faithful_graph else {
+                return;
+            };
+            let due = {
+                let mut graph = graph.lock().unwrap();
+                let now = Instant::now();
+                let mut due = Vec::new();
+                let mut pending = Vec::new();
+                for scheduled in graph.scheduled.drain(..) {
+                    if scheduled.at <= now {
+                        due.push(scheduled);
+                    } else {
+                        pending.push(scheduled);
+                    }
+                }
+                graph.scheduled = pending;
+                graph.timed_executions += due.len();
+                due
+            };
+            for scheduled in due {
+                self.insert_modeled_synth(
+                    &scheduled.def,
+                    scheduled.node,
+                    scheduled.target,
+                    scheduled.action,
+                    &scheduled.params,
+                );
+                for (param, bus) in scheduled.param_buses {
+                    self.map_param_log.lock().unwrap().push(RecordedMap {
+                        node: scheduled.node,
+                        param,
+                        bus,
+                    });
+                }
+            }
+        }
+
+        fn faithful_snapshot(&self) -> (Vec<String>, Vec<(String, NodeId)>, Vec<NodeId>, usize) {
+            self.execute_due();
+            let graph = self.faithful_graph.as_ref().unwrap().lock().unwrap();
+            let mut synths: Vec<_> = graph
+                .nodes
+                .iter()
+                .filter_map(|(id, node)| node.def.clone().map(|def| (def, *id)))
+                .collect();
+            synths.sort_by_key(|(_, id)| id.raw());
+            let mut groups: Vec<_> = graph
+                .nodes
+                .iter()
+                .filter_map(|(id, node)| (node.is_group && id.raw() != 0).then_some(*id))
+                .collect();
+            groups.sort_by_key(|id| id.raw());
+            (
+                graph.violations.clone(),
+                synths,
+                groups,
+                graph.timed_executions,
+            )
         }
 
         fn synths(&self) -> Vec<RecordedSynth> {
@@ -4957,43 +5338,126 @@ mod tests {
             action: AddAction,
             params: &ParamMap,
         ) -> std::result::Result<(), Self::Error> {
-            let link_outbus = params.get("outbus").copied();
-            self.create_synth_log.lock().unwrap().push(RecordedSynth {
-                def: def.to_string(),
-                node,
-                target,
-                action,
-                in_bus: params.get("in_bus").copied(),
-                out_bus: params.get("out_bus").copied(),
-                fx_bus_in: params.get("__fx_bus_in").copied(),
-                fx_bus_out: params.get("__fx_bus_out").copied(),
-                link_outbus,
-                params: params.clone(),
-            });
-            self.events.lock().unwrap().push(BackendEvent::Create {
-                def: def.to_string(),
-                node,
-                link_outbus,
-            });
+            self.execute_due();
+            self.insert_modeled_synth(def, node, target, action, params);
+            Ok(())
+        }
+
+        async fn create_synth_at(
+            &self,
+            def: &str,
+            node: NodeId,
+            target: NodeId,
+            action: AddAction,
+            params: &ParamMap,
+            param_buses: &[(String, u32)],
+            at: Option<Instant>,
+        ) -> std::result::Result<(), Self::Error> {
+            self.execute_due();
+            if let (Some(graph), Some(at)) = (&self.faithful_graph, at) {
+                if at > Instant::now() {
+                    let scheduled = ScheduledSynth {
+                        def: def.to_string(),
+                        node,
+                        target,
+                        action,
+                        params: params.clone(),
+                        param_buses: param_buses.to_vec(),
+                        at,
+                    };
+                    graph.lock().unwrap().scheduled.push(scheduled.clone());
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        let graph = graph.clone();
+                        tokio::spawn(async move {
+                            tokio::time::sleep_until(tokio::time::Instant::from_std(at)).await;
+                            let mut graph = graph.lock().unwrap();
+                            let Some(index) = graph.scheduled.iter().position(|pending| {
+                                pending.node == scheduled.node && pending.at == at
+                            }) else {
+                                return;
+                            };
+                            let scheduled = graph.scheduled.remove(index);
+                            graph.timed_executions += 1;
+                            let Some(parent) =
+                                graph.parent_for_create(scheduled.target, scheduled.action)
+                            else {
+                                return;
+                            };
+                            if graph.nodes.contains_key(&scheduled.node) {
+                                graph.violations.push(format!(
+                                    "timed spawn reused live node {}",
+                                    scheduled.node.raw()
+                                ));
+                                return;
+                            }
+                            graph.nodes.insert(
+                                scheduled.node,
+                                ModeledNode {
+                                    parent: Some(parent),
+                                    def: Some(scheduled.def),
+                                    is_group: false,
+                                },
+                            );
+                        });
+                    }
+                    return Ok(());
+                }
+            }
+            self.insert_modeled_synth(def, node, target, action, params);
+            for (param, bus) in param_buses {
+                self.map_param_log.lock().unwrap().push(RecordedMap {
+                    node,
+                    param: param.clone(),
+                    bus: *bus,
+                });
+            }
             Ok(())
         }
 
         async fn create_group(
             &self,
             node: NodeId,
-            _target: NodeId,
-            _action: AddAction,
+            target: NodeId,
+            action: AddAction,
         ) -> std::result::Result<(), Self::Error> {
+            self.execute_due();
+            if let Some(graph) = &self.faithful_graph {
+                let mut graph = graph.lock().unwrap();
+                let Some(parent) = graph.parent_for_create(target, action) else {
+                    return Ok(());
+                };
+                if graph.nodes.contains_key(&node) {
+                    graph
+                        .violations
+                        .push(format!("group reused live node {}", node.raw()));
+                    return Ok(());
+                }
+                graph.nodes.insert(
+                    node,
+                    ModeledNode {
+                        parent: Some(parent),
+                        def: None,
+                        is_group: true,
+                    },
+                );
+            }
             self.create_group_log.lock().unwrap().push(node);
             Ok(())
         }
 
         async fn free_node(&self, node: NodeId) -> std::result::Result<(), Self::Error> {
+            self.execute_due();
             self.free_node_log.lock().unwrap().push(node);
-            self.events
-                .lock()
-                .unwrap()
-                .push(BackendEvent::Free { node });
+            let removed = if let Some(graph) = &self.faithful_graph {
+                graph.lock().unwrap().remove_recursive(node)
+            } else {
+                vec![node]
+            };
+            let mut events = self.events.lock().unwrap();
+            for removed_node in removed {
+                events.push(BackendEvent::Free { node: removed_node });
+            }
             Ok(())
         }
 
@@ -5007,10 +5471,19 @@ mod tests {
 
         async fn set_param(
             &self,
-            _node: NodeId,
+            node: NodeId,
             _param: &str,
             _value: f32,
         ) -> std::result::Result<(), Self::Error> {
+            self.execute_due();
+            if let Some(graph) = &self.faithful_graph {
+                let mut graph = graph.lock().unwrap();
+                if !graph.nodes.contains_key(&node) {
+                    graph
+                        .violations
+                        .push(format!("parameter set on absent node {}", node.raw()));
+                }
+            }
             Ok(())
         }
 
@@ -5020,6 +5493,15 @@ mod tests {
             param: &str,
             bus: u32,
         ) -> std::result::Result<(), Self::Error> {
+            self.execute_due();
+            if let Some(graph) = &self.faithful_graph {
+                let mut graph = graph.lock().unwrap();
+                if !graph.nodes.contains_key(&node) {
+                    graph
+                        .violations
+                        .push(format!("parameter map on absent node {}", node.raw()));
+                }
+            }
             self.map_param_log.lock().unwrap().push(RecordedMap {
                 node,
                 param: param.to_string(),
@@ -5068,6 +5550,11 @@ mod tests {
         fn current_time(&self) -> Instant {
             Instant::now()
         }
+
+        async fn sync(&self) -> std::result::Result<(), Self::Error> {
+            self.execute_due();
+            Ok(())
+        }
     }
 
     /// Pre-register a synthdef name with explicit OutputPort descriptors so
@@ -5091,6 +5578,199 @@ mod tests {
             .await
             .synthdefs
             .insert(name.to_string());
+    }
+
+    fn register_reload_shape_voice_defaults(name: &str) {
+        vibelang_dsp::register_synthdef_ir(
+            name.to_string(),
+            vibelang_dsp::GraphIR {
+                name: name.to_string(),
+                constants: Vec::new(),
+                params: vec![
+                    vibelang_dsp::ParamSpec {
+                        name: "gate".to_string(),
+                        default: vec![1.0],
+                        index: 0,
+                        lag_ms: None,
+                    },
+                    vibelang_dsp::ParamSpec {
+                        name: "release".to_string(),
+                        default: vec![0.0],
+                        index: 1,
+                        lag_ms: None,
+                    },
+                ],
+                nodes: Vec::new(),
+                out_bus: 0,
+            },
+        );
+    }
+
+    fn reload_shape_state(index: u32, label: &str) -> reload::ScriptState {
+        use crate::reload::{EffectConfig, GroupConfig};
+        use crate::traits::{PatternConfig, Step, VoiceConfig};
+        use crate::types::{EffectId, PatternId};
+
+        let group = GroupId::new(40_000 + index);
+        let voice = VoiceId::new(41_000);
+        let effect = EffectId::new(42_000);
+        let pattern = PatternId::new(43_000);
+        let voice_synth = format!("reload_shape_{label}_voice");
+        let effect_synth = format!("reload_shape_{label}_effect");
+
+        let mut state = reload::ScriptState::new();
+        state.add_group(
+            group,
+            GroupConfig {
+                name: format!("{label}_group"),
+                effects: vec![effect],
+                ..GroupConfig::default()
+            },
+        );
+        state.add_voice(
+            voice,
+            VoiceConfig::new(format!("{label}_voice"), voice_synth, group),
+        );
+        state.add_effect(
+            effect,
+            EffectConfig {
+                group,
+                synthdef: effect_synth,
+                params: ParamMap::from([("mix".to_string(), 1.0)]),
+            },
+        );
+        // At 120 BPM this dispatches 45 ms into the backend's future, close
+        // to the 50 ms scheduler horizon and effect teardown grace.
+        state.add_pattern(
+            pattern,
+            PatternConfig::with_length(format!("{label}_pattern"), voice, 1.0)
+                .with_step(Step::at(0.09).with_param("amp", 0.5)),
+        );
+        state.playing_patterns.insert(pattern);
+        state.running_voices.insert(voice);
+        state
+    }
+
+    async fn assert_reload_shape_generation(
+        runtime: &Runtime<RecordingBackend>,
+        index: u32,
+        label: &str,
+        minimum_timed_executions: usize,
+        obsolete_group_nodes: &[NodeId],
+    ) -> NodeId {
+        use crate::types::{EffectId, PatternId};
+
+        let group = GroupId::new(40_000 + index);
+        let voice = VoiceId::new(41_000);
+        let effect = EffectId::new(42_000);
+        let pattern = PatternId::new(43_000);
+        let expected_voice = format!("reload_shape_{label}_voice");
+        let expected_effect = format!("reload_shape_{label}_effect");
+
+        let state = runtime.state.read().await;
+        assert_eq!(state.groups.len(), 1);
+        assert!(state.groups.contains_key(&group));
+        let current_group_node = state.groups[&group].node_id;
+        assert_eq!(state.voices.len(), 1);
+        let live_voice = state.voices.get(&voice).expect("active voice");
+        assert_eq!(live_voice.config.synthdef, expected_voice);
+        assert!(!live_voice.active_nodes.is_empty());
+        assert_eq!(state.effects.len(), 1);
+        assert_eq!(state.effects[&effect].synthdef, expected_effect);
+        assert_eq!(state.patterns.len(), 1);
+        assert!(state.patterns[&pattern].playing);
+        drop(state);
+
+        let (violations, synths, live_group_nodes, timed_executions) =
+            runtime.backend.faithful_snapshot();
+        assert!(violations.is_empty(), "backend violations: {violations:#?}");
+        assert!(
+            live_group_nodes.contains(&current_group_node),
+            "current script group node must be live: {live_group_nodes:?}"
+        );
+        for obsolete in obsolete_group_nodes {
+            assert!(
+                !live_group_nodes.contains(obsolete),
+                "obsolete script group generation {obsolete:?} is still live: {live_group_nodes:?}; frees: {:?}",
+                runtime.backend.free_node_log.lock().unwrap()
+            );
+        }
+        assert!(timed_executions >= minimum_timed_executions);
+
+        let voice_generations: std::collections::HashSet<_> = synths
+            .iter()
+            .filter_map(|(def, _)| def.starts_with("reload_shape_").then_some(def.as_str()))
+            .filter(|def| def.ends_with("_voice"))
+            .collect();
+        let effect_generations: std::collections::HashSet<_> = synths
+            .iter()
+            .filter_map(|(def, _)| def.starts_with("reload_shape_").then_some(def.as_str()))
+            .filter(|def| def.ends_with("_effect"))
+            .collect();
+        assert_eq!(
+            voice_generations,
+            std::collections::HashSet::from([expected_voice.as_str()])
+        );
+        assert_eq!(
+            effect_generations,
+            std::collections::HashSet::from([expected_effect.as_str()])
+        );
+        current_group_node
+    }
+
+    async fn settle_reload_shape_teardown(runtime: &mut Runtime<RecordingBackend>) {
+        tokio::time::sleep(std::time::Duration::from_millis(110)).await;
+        runtime.effects.tick().await;
+        runtime.voices.tick().await;
+        runtime.groups.tick().await;
+        runtime.backend.sync().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn structural_reload_is_parent_safe_and_scheduler_safe() {
+        use vibelang_dsp::{OutputPort, PortRate};
+
+        let mut runtime = Runtime::new(RecordingBackend::faithful());
+        for label in ["pads", "jungle_breaks", "heartbeat"] {
+            let voice_synth = format!("reload_shape_{label}_voice");
+            let effect_synth = format!("reload_shape_{label}_effect");
+            register_reload_shape_voice_defaults(&voice_synth);
+            register_voice_synthdef(
+                &runtime,
+                &voice_synth,
+                vec![OutputPort {
+                    name: "out".to_string(),
+                    channels: 2,
+                    rate: PortRate::Ar,
+                }],
+            )
+            .await;
+            register_effect_synthdef(&runtime, &effect_synth).await;
+        }
+
+        runtime
+            .apply_reload(reload_shape_state(0, "pads"))
+            .await
+            .unwrap();
+        let pads_group = assert_reload_shape_generation(&runtime, 0, "pads", 0, &[]).await;
+        runtime.patterns.tick(Beat::ZERO).await;
+
+        runtime
+            .apply_reload(reload_shape_state(1, "jungle_breaks"))
+            .await
+            .unwrap();
+        settle_reload_shape_teardown(&mut runtime).await;
+        let jungle_group =
+            assert_reload_shape_generation(&runtime, 1, "jungle_breaks", 1, &[pads_group]).await;
+        runtime.patterns.tick(Beat::ZERO).await;
+
+        runtime
+            .apply_reload(reload_shape_state(2, "heartbeat"))
+            .await
+            .unwrap();
+        settle_reload_shape_teardown(&mut runtime).await;
+        assert_reload_shape_generation(&runtime, 2, "heartbeat", 2, &[pads_group, jungle_group])
+            .await;
     }
 
     #[tokio::test]

--- a/crates/vibelang-core/src/runtime.rs
+++ b/crates/vibelang-core/src/runtime.rs
@@ -3722,7 +3722,7 @@ mod tests {
     use crate::reload::ParamRouteKind;
     use crate::state::GroupState;
     use crate::types::{Beat, BufferId, BusId, GroupId, NodeId, ParamMap, VoiceId};
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::path::Path;
     use std::sync::{Arc, Mutex};
     use tracing_subscriber::layer::SubscriberExt;
@@ -5074,6 +5074,7 @@ mod tests {
         /// id back into the next create.
         events: std::sync::Mutex<Vec<BackendEvent>>,
         faithful_graph: Option<Arc<std::sync::Mutex<FaithfulGraph>>>,
+        ended_nodes: std::sync::Mutex<HashSet<NodeId>>,
     }
 
     #[derive(Clone, Debug)]
@@ -5121,6 +5122,7 @@ mod tests {
                 map_param_log: std::sync::Mutex::new(Vec::new()),
                 events: std::sync::Mutex::new(Vec::new()),
                 faithful_graph: None,
+                ended_nodes: std::sync::Mutex::new(HashSet::new()),
             }
         }
 
@@ -5139,6 +5141,7 @@ mod tests {
             action: AddAction,
             params: &ParamMap,
         ) {
+            self.ended_nodes.lock().unwrap().remove(&node);
             let link_outbus = params.get("outbus").copied();
             self.create_synth_log.lock().unwrap().push(RecordedSynth {
                 def: def.to_string(),
@@ -5226,6 +5229,18 @@ mod tests {
                     });
                 }
             }
+        }
+
+        fn self_end(&self, node: NodeId) {
+            self.execute_due();
+            let graph = self.faithful_graph.as_ref().expect("faithful graph");
+            let removed = graph.lock().unwrap().nodes.remove(&node);
+            assert!(removed.is_some(), "modeled node {node:?} must be live");
+            self.ended_nodes.lock().unwrap().insert(node);
+            self.events
+                .lock()
+                .unwrap()
+                .push(BackendEvent::Free { node });
         }
 
         fn faithful_snapshot(&self) -> (Vec<String>, Vec<(String, NodeId)>, Vec<NodeId>, usize) {
@@ -5422,6 +5437,7 @@ mod tests {
             action: AddAction,
         ) -> std::result::Result<(), Self::Error> {
             self.execute_due();
+            self.ended_nodes.lock().unwrap().remove(&node);
             if let Some(graph) = &self.faithful_graph {
                 let mut graph = graph.lock().unwrap();
                 let Some(parent) = graph.parent_for_create(target, action) else {
@@ -5459,6 +5475,10 @@ mod tests {
                 events.push(BackendEvent::Free { node: removed_node });
             }
             Ok(())
+        }
+
+        fn node_has_ended(&self, node: NodeId) -> bool {
+            self.ended_nodes.lock().unwrap().contains(&node)
         }
 
         async fn run_node(
@@ -5771,6 +5791,112 @@ mod tests {
         settle_reload_shape_teardown(&mut runtime).await;
         assert_reload_shape_generation(&runtime, 2, "heartbeat", 2, &[pads_group, jungle_group])
             .await;
+    }
+
+    #[tokio::test]
+    async fn voice_reclaim_skips_fallback_free_after_definitive_node_end() {
+        use crate::traits::VoiceConfig;
+        use vibelang_dsp::{OutputPort, PortRate};
+
+        let runtime = Runtime::new(RecordingBackend::faithful());
+        let group = GroupId::new(44_001);
+        let voice = VoiceId::new(44_002);
+        let synth = "reload_done_action_gated";
+        register_reload_shape_voice_defaults(synth);
+        register_voice_synthdef(
+            &runtime,
+            synth,
+            vec![OutputPort {
+                name: "out".to_string(),
+                channels: 2,
+                rate: PortRate::Ar,
+            }],
+        )
+        .await;
+        runtime.groups.create(group, "gated", None).await.unwrap();
+        runtime
+            .voices
+            .create(voice, VoiceConfig::new("gated", synth, group))
+            .await
+            .unwrap();
+        runtime
+            .voices
+            .trigger(voice, &ParamMap::new())
+            .await
+            .unwrap();
+        let node = runtime.state.read().await.voices[&voice].active_nodes[0];
+
+        runtime.voices.stop(voice).await.unwrap();
+        runtime.backend.self_end(node);
+        tokio::time::sleep(std::time::Duration::from_millis(110)).await;
+        runtime.voices.tick().await;
+
+        assert!(runtime.backend.free_node_log.lock().unwrap().is_empty());
+        let (violations, _, _, _) = runtime.backend.faithful_snapshot();
+        assert!(violations.is_empty(), "backend violations: {violations:#?}");
+    }
+
+    #[tokio::test]
+    async fn gateless_one_shot_end_is_not_freed_again_on_polyphony_reclaim() {
+        use crate::traits::VoiceConfig;
+        use vibelang_dsp::{OutputPort, PortRate};
+
+        let runtime = Runtime::new(RecordingBackend::faithful());
+        let group = GroupId::new(45_001);
+        let voice = VoiceId::new(45_002);
+        let synth = "reload_done_action_one_shot";
+        register_voice_synthdef(
+            &runtime,
+            synth,
+            vec![OutputPort {
+                name: "out".to_string(),
+                channels: 2,
+                rate: PortRate::Ar,
+            }],
+        )
+        .await;
+        runtime
+            .groups
+            .create(group, "one-shot", None)
+            .await
+            .unwrap();
+        runtime
+            .voices
+            .create(
+                voice,
+                VoiceConfig::new("one-shot", synth, group).with_polyphony(1),
+            )
+            .await
+            .unwrap();
+
+        runtime
+            .voices
+            .trigger(voice, &ParamMap::new())
+            .await
+            .unwrap();
+        let first = runtime.state.read().await.voices[&voice].active_nodes[0];
+        runtime.backend.self_end(first);
+
+        runtime
+            .voices
+            .trigger(voice, &ParamMap::new())
+            .await
+            .unwrap();
+        let second = runtime.state.read().await.voices[&voice].active_nodes[0];
+        assert_ne!(second, first);
+        runtime.backend.self_end(second);
+
+        runtime
+            .voices
+            .trigger(voice, &ParamMap::new())
+            .await
+            .unwrap();
+        let third = runtime.state.read().await.voices[&voice].active_nodes[0];
+        assert_eq!(third, first, "definitively ended ID should be reusable");
+
+        assert!(runtime.backend.free_node_log.lock().unwrap().is_empty());
+        let (violations, _, _, _) = runtime.backend.faithful_snapshot();
+        assert!(violations.is_empty(), "backend violations: {violations:#?}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- quiesce and drain pattern/melody lookahead before tearing down affected voices and groups
- create replacement parent groups before structural voice recreation, detach effects before parent teardown, and order deferred child reclaim before group reclaim
- retain node and bus ownership until backend teardown, and suppress stale voice frees after a definitive scsynth `/n_end`
- add a recursive/timed backend model covering structural `pads -> jungle-breaks -> heartbeat` reloads plus gated doneAction and gateless one-shot lifecycle regressions

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vibelang-core --lib --all-features` (761 passed)
- `cargo check -p vibelang-core --no-default-features --features native,midi`
- `cargo check -p vibelang-core --no-default-features`
- Bela HIL against SuperGamma `248be0d`, eight recalls in order: acid-circuit, deep-orbit, dub-chamber, glass-arp, jungle-breaks, heartbeat, lead, pads
  - all eight active preset, expected voices, `/live=200`, reload successful/complete, and one rendered marker block
  - zero VibeLang/scsynth/control errors in every transition delta
  - zero absent-node or other `FAILURE IN SERVER` records across the complete scsynth log
  - clean `make stop`; Bela audio/runtime processes absent and `bela_button` restored

## Scope

The PR contains only `vibelang-core` reload/backend changes. It does not include the unrelated ALSA UMP workspace changes.