### PR TITLE
fix(rhai): resolve fx param routes, propagate group-body errors

### DIFF
--- a/crates/vibelang-cli/src/main.rs
+++ b/crates/vibelang-cli/src/main.rs
@@ -300,9 +300,16 @@ async fn run_simple_mode(
     output_channels: u32,
     ext_config: ExtensionSettings,
 ) -> Result<()> {
-    // Initialize logging - uses RUST_LOG env var
+    // Initialize logging - uses RUST_LOG env var.
+    //
+    // With RUST_LOG unset the env filter is empty, which silences *every*
+    // level — including the `error!` a failed hot reload emits, so a broken
+    // script looked like a successful one. Default to `warn` so real
+    // failures are visible out of the box; RUST_LOG still overrides.
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
+        )
         .init();
 
     // Setup shutdown signal

--- a/crates/vibelang-rhai/src/api/group.rs
+++ b/crates/vibelang-rhai/src/api/group.rs
@@ -377,7 +377,7 @@ pub fn define_group(
     // Propagate closure failures instead of logging them: the body builds the
     // group's whole graph, so swallowing an error here ships a half-built
     // group as silence and lets `vibe run` exit 0 on a broken script.
-    context::with_group_path(&full_path, || {
+    let _ = context::with_group_path(&full_path, || {
         closure
             .call_within_context::<rhai::Dynamic>(&ctx, ())
             .map_err(|e| group_body_error("define_group", &group_name, e))

--- a/crates/vibelang-rhai/src/api/group.rs
+++ b/crates/vibelang-rhai/src/api/group.rs
@@ -374,11 +374,14 @@ pub fn define_group(
         state.groups.entry(group_id).or_insert(config);
     });
 
+    // Propagate closure failures instead of logging them: the body builds the
+    // group's whole graph, so swallowing an error here ships a half-built
+    // group as silence and lets `vibe run` exit 0 on a broken script.
     context::with_group_path(&full_path, || {
-        if let Err(e) = closure.call_within_context::<rhai::Dynamic>(&ctx, ()) {
-            log::error!("Error in define_group '{}': {}", group_name, e);
-        }
-    });
+        closure
+            .call_within_context::<rhai::Dynamic>(&ctx, ())
+            .map_err(|e| group_body_error("define_group", &group_name, e))
+    })?;
 
     Ok(GroupHandle::new(full_path))
 }
@@ -387,7 +390,11 @@ pub fn define_group(
 ///
 /// This is the builder equivalent of `define_group("name", || { ... })`.
 /// The closure executes in the group's context, allowing nested definitions.
-fn group_body(ctx: NativeCallContext, handle: GroupHandle, closure: FnPtr) -> GroupHandle {
+fn group_body(
+    ctx: NativeCallContext,
+    handle: GroupHandle,
+    closure: FnPtr,
+) -> Result<GroupHandle, Box<EvalAltResult>> {
     let group_id = context::get_or_create_group_id(&handle.path);
 
     context::with_state(|state| {
@@ -408,13 +415,23 @@ fn group_body(ctx: NativeCallContext, handle: GroupHandle, closure: FnPtr) -> Gr
     let result = context::with_group_path(&handle.path, || {
         closure.call_within_context::<rhai::Dynamic>(&ctx, ())
     });
+    // End the contribution before propagating: the body-contribution stack
+    // must unwind even when the closure failed.
     context::end_body_contribution(contribution_id);
 
-    if let Err(e) = result {
-        log::error!("Error in group('{}').body(): {}", handle.name, e);
-    }
+    let _ = result.map_err(|e| group_body_error("group body", &handle.name, e))?;
 
-    handle
+    Ok(handle)
+}
+
+/// Wrap a failing group-body closure error so the script author sees which
+/// group's body failed, with the underlying error preserved as the message.
+fn group_body_error(verb: &str, group_name: &str, err: Box<EvalAltResult>) -> Box<EvalAltResult> {
+    let pos = err.position();
+    Box::new(EvalAltResult::ErrorRuntime(
+        format!("{}('{}'): {}", verb, group_name, err).into(),
+        pos,
+    ))
 }
 
 /// Register an authoring alias for a canonical group handle.

--- a/crates/vibelang-rhai/src/api/route.rs
+++ b/crates/vibelang-rhai/src/api/route.rs
@@ -19,7 +19,10 @@ use rhai::{CustomType, Dynamic, Engine, EvalAltResult, Position, TypeBuilder};
 use vibelang_core::handlers::{InputRouteSrc, ParamRouteTarget, RouteDest};
 use vibelang_core::reload::{ParamRouteConflict, ParamRouteKind};
 use vibelang_core::types::VoiceId;
-use vibelang_dsp::{get_synthdef_outputs, get_synthdef_param_defaults, OutputPort, PortRate};
+use vibelang_dsp::{
+    get_effect_param_defaults, get_synthdef_outputs, get_synthdef_param_defaults, OutputPort,
+    PortRate,
+};
 
 use super::group::GroupHandle;
 use super::sequence::Fx;
@@ -127,6 +130,24 @@ impl RouteHandle {
             );
         });
         Ok(self)
+    }
+
+    /// Fx-target overload of [`Self::to_input`] — always an error.
+    ///
+    /// `define_fx` modules are **group inserts**: the body receives the group
+    /// bus as its `input` and writes back in place, so an fx has no
+    /// addressable named input port to route into. Input routes are keyed by
+    /// `(VoiceId, port)` end-to-end, and there is no effect-side equivalent.
+    ///
+    /// Registered purely so the script author gets an actionable message
+    /// naming the two supported ways to express the patch, instead of Rhai's
+    /// bare `Function not found: to_input (RouteHandle, Fx, String)`.
+    pub fn to_input_fx(self, target: Fx, input_name: String) -> Result<Self, Box<EvalAltResult>> {
+        Err(fx_input_route_error(
+            &self.port_name,
+            &target.id,
+            &input_name,
+        ))
     }
 
     /// Install a CV-to-param route from this kr-rate output port to the named
@@ -422,19 +443,46 @@ impl ParamSourceValidation {
 
     fn unknown_target_param_error(
         self,
+        target: ParamRouteTarget,
         target_name: &str,
         target_synth: &str,
         param: &str,
         available: &std::collections::HashMap<String, f32>,
     ) -> Box<EvalAltResult> {
+        let kind = target_kind_noun(target);
         match self {
-            Self::ModulateBy => {
-                modulate_by_unknown_target_param_error(target_name, target_synth, param, available)
-            }
+            Self::ModulateBy => modulate_by_unknown_target_param_error(
+                kind,
+                target_name,
+                target_synth,
+                param,
+                available,
+            ),
             Self::ToParam | Self::ToParamAudio | Self::ToTrigger => {
-                unknown_target_param_error(target_name, target_synth, param, available)
+                unknown_target_param_error(kind, target_name, target_synth, param, available)
             }
         }
+    }
+}
+
+/// Declared params of a param-route target, read from the registry that owns
+/// the target kind: synthdefs for voices, `define_fx` bodies for effects.
+fn target_param_defaults(
+    target: ParamRouteTarget,
+    target_synth: &str,
+) -> std::collections::HashMap<String, f32> {
+    match target {
+        ParamRouteTarget::Voice(_) => get_synthdef_param_defaults(target_synth),
+        ParamRouteTarget::Effect(_) => get_effect_param_defaults(target_synth),
+    }
+}
+
+/// User-facing noun for a param-route target, so errors name what the script
+/// actually wrote (`voice` vs `fx`) instead of always saying "voice".
+fn target_kind_noun(target: ParamRouteTarget) -> &'static str {
+    match target {
+        ParamRouteTarget::Voice(_) => "voice",
+        ParamRouteTarget::Effect(_) => "fx",
     }
 }
 
@@ -463,9 +511,15 @@ fn install_param_route(
         }
     }
 
-    let target_params = get_synthdef_param_defaults(target_synth);
+    // Resolve the target's declared params from the registry that actually
+    // owns them: voice targets live in the synthdef registry, fx targets
+    // (`define_fx`) in the effect registry. Looking an fx up in the synthdef
+    // registry yields an empty param set, which rejected every fx param
+    // route.
+    let target_params = target_param_defaults(target, target_synth);
     if !target_params.contains_key(&target_param) {
         return Err(validation.unknown_target_param_error(
+            target,
             target_name,
             target_synth,
             &target_param,
@@ -713,7 +767,8 @@ fn missing_source_port_error(
 }
 
 fn unknown_target_param_error(
-    target_voice: &str,
+    target_kind: &str,
+    target_name: &str,
     target_synth: &str,
     param: &str,
     available: &std::collections::HashMap<String, f32>,
@@ -731,9 +786,31 @@ fn unknown_target_param_error(
     };
     Box::new(EvalAltResult::ErrorRuntime(
         format!(
-            "to_param(): target voice '{}' synthdef '{}' has no param '{}' \
+            "to_param(): target {} '{}' synthdef '{}' has no param '{}' \
              (available: {})",
-            target_voice, target_synth, param, avail_list
+            target_kind, target_name, target_synth, param, avail_list
+        )
+        .into(),
+        Position::NONE,
+    ))
+}
+
+/// Error for `source.output(port).to_input(fx, name)` — fx are group-scope
+/// inserts and cannot be per-port routing destinations.
+fn fx_input_route_error(port: &str, fx_id: &str, input_name: &str) -> Box<EvalAltResult> {
+    Box::new(EvalAltResult::ErrorRuntime(
+        format!(
+            "to_input() on port '{}': target '{}' is an fx, and fx are \
+             group-scope inserts with no named input ports — `define_fx` \
+             bodies receive the group bus as their input and write it back \
+             in place, so '{}' cannot be addressed. Either (a) route the \
+             port into a sub-group that owns the fx \
+             (`v.output(\"{}\").to(group(\"fx_chain\").effect(\"...\"))`), or \
+             (b) make the processor a voice: declare the input on its \
+             synthdef with `.input(\"{}\")` and route \
+             `.to_input(voice, \"{}\")`. Fx params remain routable with \
+             `.to_param(fx, \"param\")` / `fx.param(\"param\").modulate_by(...)`.",
+            port, fx_id, input_name, port, input_name, input_name
         )
         .into(),
         Position::NONE,
@@ -946,7 +1023,8 @@ fn modulate_by_missing_source_port_error(
 }
 
 fn modulate_by_unknown_target_param_error(
-    target_voice: &str,
+    target_kind: &str,
+    target_name: &str,
     target_synth: &str,
     param: &str,
     available: &std::collections::HashMap<String, f32>,
@@ -964,9 +1042,9 @@ fn modulate_by_unknown_target_param_error(
     };
     Box::new(EvalAltResult::ErrorRuntime(
         format!(
-            "modulate_by(): target voice '{}' synthdef '{}' has no param '{}' \
+            "modulate_by(): target {} '{}' synthdef '{}' has no param '{}' \
              (available: {})",
-            target_voice, target_synth, param, avail_list
+            target_kind, target_name, target_synth, param, avail_list
         )
         .into(),
         Position::NONE,
@@ -1159,6 +1237,9 @@ pub fn register(engine: &mut Engine) {
     engine.register_fn("mute", RouteHandle::mute);
     engine.register_fn("to_current_group", RouteHandle::to_current_group);
     engine.register_fn("to_input", RouteHandle::to_input);
+    // Fx destinations are rejected with an actionable message rather than a
+    // bare Rhai "Function not found" — see `to_input_fx`.
+    engine.register_fn("to_input", RouteHandle::to_input_fx);
     // Voice-target verbs (existing surface).
     engine.register_fn("to_param", RouteHandle::to_param);
     engine.register_fn("to_param_audio", RouteHandle::to_param_audio);
@@ -1202,10 +1283,12 @@ mod tests {
     //! `RouteDest::Param` semantics: `(target_voice_id, target_param_name)`
     //! pairs keyed by source `(voice_id, port_name)`).
     use super::ParamRouteTarget;
+    use crate::api::sequence::Fx;
     use crate::api::voice::Voice;
     use crate::context;
     use vibelang_dsp::{
-        register_synthdef_ir, register_synthdef_outputs, GraphIR, OutputPort, ParamSpec, PortRate,
+        register_effect_ir, register_synthdef_ir, register_synthdef_outputs, GraphIR, OutputPort,
+        ParamSpec, PortRate,
     };
 
     fn with_test_context<F: FnOnce()>(f: F) {
@@ -2737,6 +2820,156 @@ mod tests {
                 assert!(state
                     .input_routes
                     .contains_key(&(voc_id, "carrier".to_string())));
+            });
+        });
+    }
+    /// Declare a `define_fx`-style effect with the named params. Effects live
+    /// in the EFFECT registry, not the synthdef registry — the distinction
+    /// this block of tests exists to pin.
+    fn declare_effect_with_params(name: &str, params: &[&str]) {
+        let param_specs: Vec<ParamSpec> = params
+            .iter()
+            .enumerate()
+            .map(|(i, n)| ParamSpec {
+                name: (*n).to_string(),
+                default: vec![0.0],
+                index: i,
+                lag_ms: None,
+            })
+            .collect();
+        register_effect_ir(
+            name.to_string(),
+            GraphIR {
+                name: name.to_string(),
+                constants: vec![],
+                params: param_specs,
+                nodes: vec![],
+                out_bus: 0,
+            },
+        );
+    }
+
+    /// Regression: `fx.param("cutoff").modulate_by(lfo, "out")` used to be
+    /// rejected because the target param set was read from the SYNTHDEF
+    /// registry, where a `define_fx` name has no entry — so every fx param
+    /// looked undeclared and LFO->fx modulation was dead on the device.
+    #[test]
+    fn modulate_by_fx_param_installs_route() {
+        with_test_context(|| {
+            let src_synth = "fxparam_modby_src";
+            let fx_synth = "fxparam_modby_fx";
+            declare_kr_synthdef(src_synth, &["out"]);
+            declare_effect_with_params(fx_synth, &["cutoff", "res"]);
+
+            let src = make_voice("vox_src_modby_fx").synth(src_synth.to_string());
+            let mut target = Fx::for_test("fx_modby_target", fx_synth);
+
+            target
+                .param_handle("cutoff")
+                .modulate_by(src, "out".to_string())
+                .expect("fx param resolves through the effect registry");
+
+            let src_id = context::get_or_create_voice_id("vox_src_modby_fx");
+            let fx_id = context::get_or_create_effect_id("fx_modby_target");
+            context::with_state(|state| {
+                let entries = state
+                    .param_routes_bend
+                    .get(&(src_id, "out".to_string()))
+                    .expect("param route installed");
+                assert_eq!(
+                    entries.as_slice(),
+                    &[(ParamRouteTarget::Effect(fx_id), "cutoff".to_string())]
+                );
+            });
+        });
+    }
+
+    /// Source-first dual of the above: `lfo.output("out").to_param(fx, ...)`
+    /// shared the same broken registry lookup.
+    #[test]
+    fn to_param_fx_target_installs_route() {
+        with_test_context(|| {
+            let src_synth = "fxparam_toparam_src";
+            let fx_synth = "fxparam_toparam_fx";
+            declare_kr_synthdef(src_synth, &["env"]);
+            declare_effect_with_params(fx_synth, &["mix"]);
+
+            let mut src = make_voice("vox_src_toparam_fx").synth(src_synth.to_string());
+            let target = Fx::for_test("fx_toparam_target", fx_synth);
+
+            src.output_by_name("env")
+                .expect("port resolves")
+                .to_param_fx(target, "mix".to_string())
+                .expect("fx param resolves through the effect registry");
+
+            let src_id = context::get_or_create_voice_id("vox_src_toparam_fx");
+            let fx_id = context::get_or_create_effect_id("fx_toparam_target");
+            context::with_state(|state| {
+                let entries = state
+                    .param_routes_set
+                    .get(&(src_id, "env".to_string()))
+                    .expect("param route installed");
+                assert_eq!(
+                    entries.as_slice(),
+                    &[(ParamRouteTarget::Effect(fx_id), "mix".to_string())]
+                );
+            });
+        });
+    }
+
+    /// A genuinely undeclared fx param still errors — and names the target as
+    /// an `fx`, listing the effect's declared params rather than `<none>`.
+    #[test]
+    fn modulate_by_unknown_fx_param_errors_with_effect_params() {
+        with_test_context(|| {
+            let src_synth = "fxparam_unknown_src";
+            let fx_synth = "fxparam_unknown_fx";
+            declare_kr_synthdef(src_synth, &["out"]);
+            declare_effect_with_params(fx_synth, &["cutoff", "res"]);
+
+            let src = make_voice("vox_src_unknown_fx").synth(src_synth.to_string());
+            let mut target = Fx::for_test("fx_unknown_target", fx_synth);
+
+            let err = target
+                .param_handle("nope")
+                .modulate_by(src, "out".to_string())
+                .expect_err("unknown fx param must error");
+            let msg = err.to_string();
+            assert!(msg.contains("target fx"), "msg = {}", msg);
+            assert!(msg.contains("'nope'"), "msg = {}", msg);
+            assert!(msg.contains("'cutoff'"), "msg = {}", msg);
+            assert!(msg.contains("'res'"), "msg = {}", msg);
+        });
+    }
+
+    /// `to_input` onto an fx is rejected with an actionable message naming
+    /// both supported alternatives, instead of Rhai's bare
+    /// "Function not found: to_input (RouteHandle, Fx, String)".
+    #[test]
+    fn to_input_fx_target_errors_with_actionable_message() {
+        with_test_context(|| {
+            let src_synth = "fxinput_src";
+            declare_ar_synthdef(src_synth, &["out"]);
+            declare_effect_with_params("fxinput_fx", &["cutoff"]);
+
+            let mut src = make_voice("vox_src_fxinput").synth(src_synth.to_string());
+            let target = Fx::for_test("fx_input_target", "fxinput_fx");
+
+            let err = src
+                .output_by_name("out")
+                .expect("port resolves")
+                .to_input_fx(target, "carrier".to_string())
+                .expect_err("fx is not a routable input destination");
+            let msg = err.to_string();
+            assert!(msg.contains("fx_input_target"), "msg = {}", msg);
+            assert!(msg.contains("group-scope inserts"), "msg = {}", msg);
+            assert!(msg.contains("to_param"), "msg = {}", msg);
+
+            // Nothing was written into the input-route map.
+            let src_id = context::get_or_create_voice_id("vox_src_fxinput");
+            context::with_state(|state| {
+                assert!(state.routes.get(&(src_id, "out".to_string())).is_none());
+                assert!(state.input_routes.is_empty());
             });
         });
     }

--- a/crates/vibelang-rhai/src/api/sequence.rs
+++ b/crates/vibelang-rhai/src/api/sequence.rs
@@ -672,6 +672,21 @@ impl Fx {
         }
     }
 
+    /// Construct an `Fx` outside Rhai's calling convention, for tests.
+    ///
+    /// Mirrors [`Voice::for_test`](crate::api::voice::Voice) — skips the
+    /// `NativeCallContext` that `Fx::new` needs so sibling test modules
+    /// (`route.rs`) can exercise fx-target route handles directly.
+    #[cfg(test)]
+    pub(crate) fn for_test(id: &str, synth_name: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            synth_name: Some(synth_name.to_string()),
+            params: HashMap::new(),
+            group_path: context::current_group_path(),
+        }
+    }
+
     /// Set the synthdef for this effect.
     pub fn synth(mut self, synth_name: String) -> Self {
         self.synth_name = Some(synth_name);

--- a/crates/vibelang-rhai/src/engine.rs
+++ b/crates/vibelang-rhai/src/engine.rs
@@ -1630,9 +1630,12 @@ mod tests {
     }
 
     #[test]
-    fn test_group_body_restores_context_after_inner_body_error() {
+    fn test_group_body_error_propagates_and_names_group_chain() {
+        // A failing body used to be swallowed with a `log::error!`, so the
+        // script "succeeded" with a half-built graph. It now aborts the run
+        // and reports which group's body failed, innermost first.
         let mut engine = ScriptEngine::new();
-        let state = engine
+        let err = engine
             .execute(
                 r#"
             group("Outer").body(|| {
@@ -1644,27 +1647,37 @@ mod tests {
             });
         "#,
             )
-            .unwrap();
+            .expect_err("an error inside a group body must fail the script");
 
-        let outer_id = state
+        let msg = err.to_string();
+        assert!(msg.contains("Outer"), "msg = {}", msg);
+        assert!(msg.contains("Inner"), "msg = {}", msg);
+        assert!(msg.contains("missing_function"), "msg = {}", msg);
+
+        // The group-path context still unwinds: a later run is unaffected by
+        // the aborted one and puts its voice under its own group, not under
+        // the leaked "Outer/Inner" path.
+        let state = engine
+            .execute(
+                r#"
+            group("Fresh").body(|| {
+                voice("fresh_voice").synth("pad_synth");
+            });
+        "#,
+            )
+            .expect("engine stays usable after a failed group body");
+
+        let fresh_id = state
             .groups
             .iter()
-            .find_map(|(id, config)| (config.name == "Outer").then_some(*id))
-            .expect("Outer group should exist");
-        let inner_id = state
-            .groups
-            .iter()
-            .find_map(|(id, config)| (config.name == "Inner").then_some(*id))
-            .expect("Inner group should exist");
-
-        let outer_after = state
+            .find_map(|(id, config)| (config.name == "Fresh").then_some(*id))
+            .expect("Fresh group should exist");
+        let fresh_voice = state
             .voices
             .values()
-            .find(|voice| voice.name == "outer_after")
-            .expect("outer_after voice should exist");
-
-        assert_eq!(outer_after.group, outer_id);
-        assert_ne!(outer_after.group, inner_id);
+            .find(|voice| voice.name == "fresh_voice")
+            .expect("fresh_voice should exist");
+        assert_eq!(fresh_voice.group, fresh_id);
     }
 
     #[test]

--- a/examples/spectraphon_array_capture.vibe
+++ b/examples/spectraphon_array_capture.vibe
@@ -40,7 +40,13 @@ let capture_demo = define_group("ArrayCapture", || {
         .synth("test_saw")
         .set_param("freq", 110.0)
         .set_param("amp", 0.20);
-    source.output("out").mute();
+    // The saw is an analysis source only — it must reach `cap_osc.analyze`
+    // without leaking into the mix. `.mute()` is not usable here: a muted
+    // port is rejected as a named-input source, so route the port into a
+    // dedicated sub-group attenuated to silence instead. The `analyze`
+    // link reads the port's own bus, which is allocated either way.
+    let analysis_only = group("analysis_only").gain(0.0);
+    source.output("out").to(analysis_only);
 
     // Capture leg: a single Spectraphon voice analyzes `source` and writes
     // the live magnitude bank into the SAO array buffer.

--- a/kb/voice-multioutput-howto.md
+++ b/kb/voice-multioutput-howto.md
@@ -938,6 +938,17 @@ non-crossed bullets are deferred non-features.
   routes it through `port_tr_to_param_link_1` for sample-accurate
   edge forwarding (§3f). No scale/offset on triggers and no fan-in;
   trigger routing is 1:1.
+* **Fx are group-scope inserts, not per-port audio destinations.** A
+  `define_fx` body receives the group bus as its `input` and writes it
+  back in place, so an fx has no named input port to patch into —
+  input routes are keyed `(VoiceId, port)` end-to-end. `.to_input(fx,
+  "name")` is therefore rejected with an error naming the two
+  supported spellings: route the port into a sub-group that owns the
+  fx (§3b), or make the processor a voice whose synthdef declares
+  `.input("name")` (§5a). Fx **params** are fully routable in both
+  directions — `.to_param(fx, "cutoff")` and
+  `fx.param("cutoff").modulate_by(src, "out")` resolve the param set
+  through the effect registry and `/n_map` the effect node.
 * **No `solo()`, `tap()`, `scope()`** — the wider verb table from the
   plan §5.2 is still deferred. Today the verb set is `to`, `to_main`,
   `to_current_group`, `mute`, `to_param` (kr SET), `to_param_audio`


### PR DESCRIPTION
Fixes three issues found while driving vibelang from the super-gamma instrument host.

## 1. CV-to-param routing onto a `define_fx` param always failed (HIGH)

`lfo.output("out").to_param(fx, "cutoff")` and `fx.param("cutoff").modulate_by(lfo, "out")` both errored with `has no param 'cutoff' (available: <none>)`.

`install_param_route` resolved the target's declared params with `get_synthdef_param_defaults(target_synth)` unconditionally. A `define_fx` name lives in the **effect** registry, so the lookup returned an empty map and every fx param was rejected as undeclared. Now dispatches on the `ParamRouteTarget` variant.

One fix repairs both authoring directions, since `.modulate_by` and the `.to_param` / `.to_param_audio` / `.to_trigger` fx overloads all funnel through this function. **No runtime change was needed** — `RoutesHandler` already resolves an Effect target to the effect node and `/n_map`s it, so this was purely a validation-layer false rejection. Errors now say `target fx` vs `target voice` and list the effect's real params.

Impact: every LFO/envelope → filter-cutoff patch was silently dead. MIDI CC → fx param used a different path and worked, which is why hardware knob mappings looked fine while modulation did nothing.

## 2. `define_group` closure errors were swallowed

`define_group(name, ||{..})` and `group(name).body(||{..})` only `log::error!`d closure failures, so a broken script shipped a half-built graph and `vibe run` exited 0. Both now propagate a wrapped error naming the group. Startup already does `execute_script(..)?` so it exits non-zero; the hot-reload path still logs and keeps the last good state, which is correct for live coding.

The reason it was *invisible* is fixed too: the CLI built its filter with `EnvFilter::from_default_env()`, which with `RUST_LOG` unset silences **every** level including `error!`. It now falls back to `warn`; `RUST_LOG` still overrides.

## 3. `to_input` with an fx target

Failed with Rhai's bare `Function not found: to_input (RouteHandle, Fx, String)`.

Fx are group-scope inserts — a `define_fx` body receives the group bus as `input` and writes back in place, and input routes are keyed `(VoiceId, port)` end-to-end — so an fx genuinely cannot be a per-port audio destination. **Registering real fx input ports is a design change, not a bug fix, and is not attempted here.** Instead the overload is registered to fail with an actionable message naming the two supported spellings (sub-group that owns the fx, or a voice whose synthdef declares `.input()`), and the rule is documented in `kb/voice-multioutput-howto.md` §8.

## Verification

End-to-end against a live scsynth with the reporter's repro:

| | exit | behavior |
|---|---|---|
| without fix 1 | 1 | `define_group('g'): modulate_by(): target voice 'repro_f' synthdef 'repro_filter' has no param 'cutoff' (available: <none>)` — the reported error, now propagated and wrapped by fix 2 instead of silently logged |
| with fix 1 | 0 | fx param route installs, script loads |

`examples/named_input_lowpass.vibe` still loads with zero script errors, confirming error propagation does not break working scripts.

Tests: 4 new fx-target cases in `route.rs` (install via both verbs, unknown-fx-param error text, `to_input` rejection) alongside the 44 existing route tests — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)